### PR TITLE
Forcing TLS to version 1.2

### DIFF
--- a/src/MP.cs
+++ b/src/MP.cs
@@ -497,7 +497,8 @@ namespace mercadopago {
 				
 				String responseBody = null;
 				try {
-					HttpWebResponse apiResult = (HttpWebResponse)request.GetResponse ();
+                    ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
+                    HttpWebResponse apiResult = (HttpWebResponse)request.GetResponse ();
 					responseBody = new StreamReader (apiResult.GetResponseStream ()).ReadToEnd ();
 
 					response = new Hashtable();


### PR DESCRIPTION
Forcing the security protocol to TLS1.2, to prevent the error "The underlying connection was closed. An unexpected error occurred on a send" when sending request.