### PR TITLE
Faltan atributos StringEnumConverter 

### DIFF
--- a/px-dotnet/Common/CardNumberValidation.cs
+++ b/px-dotnet/Common/CardNumberValidation.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 namespace MercadoPago.Common
 {
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum CardNumberValidation
     {
         /// <summary> The card number should validate Luhn's algorithm </summary>

--- a/px-dotnet/Common/PaymentMethodDeferredCapture.cs
+++ b/px-dotnet/Common/PaymentMethodDeferredCapture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 namespace MercadoPago.Common
 {
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum PaymentMethodDeferredCapture
     {
         /// <summary> This payment method supports authorization and capture operations </summary>

--- a/px-dotnet/Common/PaymentMethodStatus.cs
+++ b/px-dotnet/Common/PaymentMethodStatus.cs
@@ -1,6 +1,7 @@
 using System;
 namespace MercadoPago.Common
 {
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum PaymentMethodStatus
     {
         /// <summary> Available for use </summary>


### PR DESCRIPTION
## Cambios realizados para el feature:
  * Atributo StringEnumConverter falta en CardNumberValidation 
  * Atributo StringEnumConverter falta en PaymentMethodDeferredCapture
  * Atributo StringEnumConverter falta en PaymentMethodStatus

Son requeridos para serializar los enum como texto.