### PR TITLE
Place most common installation instructions first

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -17,6 +17,22 @@ Si estás utilizando versiones anteriores del .NET Framework en tu proyecto, con
 
 ## 📲 Instalación
 
+Usar una de las siguientes opciones, dependiendo de tu entorno preferido.
+
+### En el Visual Studio
+
+1. Abra el `Solution Explorer`.
+2. Haga clic con el botón derecho en un proyecto de su solución.
+3. Haga clic en `Manage NuGet Packages...`.
+4. Haga clic en la tab `Browse` y busque "mercadopago-sdk".
+5. Haga clic en el package `mercadopago-sdk`, seleccione la versión apropiada y haga clic en `Install`.
+
+### Usando el [Package Manager](https://docs.microsoft.com/es-es/nuget/tools/package-manager-console)
+
+```bash
+Install-Package mercadopago-sdk
+```
+
 ### Usando el [.NET Core command-line interface (CLI) tools](https://docs.microsoft.com/es-es/dotnet/core/tools/)
 
 ```bash
@@ -28,20 +44,6 @@ dotnet add package mercadopago-sdk
 ```bash
 nuget install mercadopago-sdk
 ```
-
-### Usando el [Package Manager](https://docs.microsoft.com/es-es/nuget/tools/package-manager-console)
-
-```bash
-Install-Package mercadopago-sdk
-```
-
-### En el Visual Studio
-
-1. Abra el `Solution Explorer`.
-2. Haga clic con el botón derecho en un proyecto de su solución.
-3. Haga clic en `Manage NuGet Packages...`.
-4. Haga clic en la tab `Browse` y busque "mercadopago-sdk".
-5. Haga clic en el package `mercadopago-sdk`, seleccione la versión apropiada y haga clic en `Install`.
 
 ## 🌟 Empezando
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,22 @@ If you are using previous versions of .NET Framework in your project, please ref
 
 ## 📲 Installation
 
+Use one of the following options, depending on your preferred environment.
+
+### From Visual Studio
+
+1. Open the `Solution Explorer`.
+2. Right-click on a project within your solution.
+3. Click on `Manage NuGet Packages...`.
+4. Click on the `Browse` tab and search for "mercadopago-sdk".
+5. Click on the `mercadopago-sdk` package, select the appropriate version and click Install.
+
+### Using the [Package Manager](https://docs.microsoft.com/en-us/nuget/tools/package-manager-console)
+
+```bash
+Install-Package mercadopago-sdk
+```
+
 ### Using the [.NET Core command-line interface (CLI) tools](https://docs.microsoft.com/en-us/dotnet/core/tools/)
 
 ```bash
@@ -28,20 +44,6 @@ dotnet add package mercadopago-sdk
 ```bash
 nuget install mercadopago-sdk
 ```
-
-### Using the [Package Manager](https://docs.microsoft.com/en-us/nuget/tools/package-manager-console)
-
-```bash
-Install-Package mercadopago-sdk
-```
-
-### From Visual Studio
-
-1. Open the `Solution Explorer`.
-2. Right-click on a project within your solution.
-3. Click on `Manage NuGet Packages...`.
-4. Click on the `Browse` tab and search for "mercadopago-sdk".
-5. Click on the `mercadopago-sdk` package, select the appropriate version and click Install.
 
 ## 🌟 Getting Started
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -17,6 +17,22 @@ Se você estiver usando versões anteriores do .NET Framework em seu projeto, co
 
 ## 📲 Instalação
 
+Use uma das seguintes opções, dependendo do ambiente preferido.
+
+### No Visual Studio
+
+1. Abra o `Solution Explorer`.
+2. Clique com o botão direito em um projeto da sua solução.
+3. Clique em `Manage NuGet Packages...`.
+4. Clique na tab `Browse` e busque por "mercadopago-sdk".
+5. Clique no package `mercadopago-sdk`, selecione a versãa apropriada e clique em `Install`.
+
+### Usando o [Package Manager](https://docs.microsoft.com/pt-br/nuget/tools/package-manager-console)
+
+```bash
+Install-Package mercadopago-sdk
+```
+
 ### Usando o [.NET Core command-line interface (CLI) tools](https://docs.microsoft.com/pt-br/dotnet/core/tools/)
 
 ```bash
@@ -28,20 +44,6 @@ dotnet add package mercadopago-sdk
 ```bash
 nuget install mercadopago-sdk
 ```
-
-### Usando o [Package Manager](https://docs.microsoft.com/pt-br/nuget/tools/package-manager-console)
-
-```bash
-Install-Package mercadopago-sdk
-```
-
-### No Visual Studio
-
-1. Abra o `Solution Explorer`.
-2. Clique com o botão direito em um projeto da sua solução.
-3. Clique em `Manage NuGet Packages...`.
-4. Clique na tab `Browse` e busque por "mercadopago-sdk".
-5. Clique no package `mercadopago-sdk`, selecione a versãa apropriada e clique em `Install`.
 
 ## 🌟 Iniciando
 


### PR DESCRIPTION
Most developers will likely use VS rather than the other options, so place the VS-related 
options first. Add note that only *one* option is needed.