### PR TITLE
Adds option to modify custom headers of request options

### DIFF
--- a/src/MercadoPago.Tests/Client/Customer/CustomerClientTest.cs
+++ b/src/MercadoPago.Tests/Client/Customer/CustomerClientTest.cs
@@ -462,7 +462,6 @@
                 Address = new CustomerDefaultAddressRequest
                 {
                     Id = "123",
-                    ZipCode = "0000200",
                     StreetName = "Street",
                     StreetNumber = 123,
                 },

--- a/src/MercadoPago/Client/RequestOptions.cs
+++ b/src/MercadoPago/Client/RequestOptions.cs
@@ -38,6 +38,6 @@
         /// <c>X-Idempotency-Key</c>, <c>X-Product-Id</c>, <c>X-Corporation-Id</c>,
         /// <c>X-Integrator-Id</c> and <c>X-Platform-Id</c> will be disconsidered.
         /// </remarks>
-        public IDictionary<string, string> CustomHeaders { get; }
+        public IDictionary<string, string> CustomHeaders { get; set; }
     }
 }


### PR DESCRIPTION
### Introduce
The purpose of this PR is add the option "set" to CustomHeaders of class RequestOptions.

### Context
When we want pass a custom header to a request, we have that generate a RequestOptions with CustomHeaders attribute filled with the values that we want. But, in current version of SDK, we don't have the "set" in CustomHeaders.