### PR TITLE
Add DefaultCard and TicketUrl properties

### DIFF
--- a/src/MercadoPago/Client/Customer/CustomerRequest.cs
+++ b/src/MercadoPago/Client/Customer/CustomerRequest.cs
@@ -40,6 +40,11 @@ namespace MercadoPago.Client.Customer
         public string DefaultAddress { get; set; }
 
         /// <summary>
+        /// Customer's default card.
+        /// </summary>
+        public string DefaultCard { get; set; }
+
+        /// <summary>
         /// Default address information.
         /// </summary>
         public CustomerDefaultAddressRequest Address { get; set; }

--- a/src/MercadoPago/Resource/Payment/PaymentTransactionData.cs
+++ b/src/MercadoPago/Resource/Payment/PaymentTransactionData.cs
@@ -31,6 +31,11 @@
         public long? FinancialInstitution { get; set; }
 
         /// <summary>
+        /// URL to access the ticket.
+        /// </summary>
+        public string TicketUrl { get; set; }
+
+        /// <summary>
         /// Bank info.
         /// </summary>
         public PaymentBankInfo BankInfo { get; set; }


### PR DESCRIPTION
Added the DefaultCard property in the CustomerRequest class so that it is possible to define the customer's default card.

Added the TicketUrl property in the TransactionData class to return the URL that accesses the rendered ticket with instructions for making the payment. This property is used only in the PIX payment method.