### PR TITLE
Versao inicial adicionado fine-discount

### DIFF
--- a/src/MercadoPago/Client/Payment/PaymentCreateRequest.cs
+++ b/src/MercadoPago/Client/Payment/PaymentCreateRequest.cs
@@ -170,5 +170,10 @@
         /// Merchant services.
         /// </summary>
         public PaymentMerchantServicesRequest MerchantServices { get; set; }
+
+        /// <summary>
+        /// Rules.
+        /// </summary>
+        public PaymentMethodRequest PaymentMethod { get; set; }
     }
 }

--- a/src/MercadoPago/Client/Payment/PaymentDataRequest.cs
+++ b/src/MercadoPago/Client/Payment/PaymentDataRequest.cs
@@ -1,0 +1,16 @@
+namespace MercadoPago.Client.Payment
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Payment's data.
+    /// </summary>
+    public class PaymentDataRequest
+    {
+        /// <summary>
+        /// Payment data.
+        /// </summary>
+        public PaymentRulesRequest Rules { get; set; }
+    }
+}

--- a/src/MercadoPago/Client/Payment/PaymentDataRequest.cs
+++ b/src/MercadoPago/Client/Payment/PaymentDataRequest.cs
@@ -9,7 +9,7 @@ namespace MercadoPago.Client.Payment
     public class PaymentDataRequest
     {
         /// <summary>
-        /// Payment data.
+        /// Payment rules.
         /// </summary>
         public PaymentRulesRequest Rules { get; set; }
     }

--- a/src/MercadoPago/Client/Payment/PaymentDiscountRequest.cs
+++ b/src/MercadoPago/Client/Payment/PaymentDiscountRequest.cs
@@ -1,0 +1,28 @@
+namespace MercadoPago.Client.Payment
+{
+    using System;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Payment's discount.
+    /// </summary>
+    public class PaymentDiscountRequest
+    {
+
+        /// <summary>
+        /// Type.
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Value.
+        /// </summary>
+        public decimal Value { get; set; }
+
+        /// <summary>
+        /// Limit date.
+        /// </summary>
+        [JsonConverter(typeof(DateWithoutHourConverter))]
+        public DateTime LimitDate { get; set; }
+    }
+}

--- a/src/MercadoPago/Client/Payment/PaymentFeeRequest.cs
+++ b/src/MercadoPago/Client/Payment/PaymentFeeRequest.cs
@@ -1,0 +1,22 @@
+namespace MercadoPago.Client.Payment
+{
+    using System;
+
+    /// <summary>
+    /// Payment's fee.
+    /// </summary>
+    public class PaymentFeeRequest
+    {
+
+        /// <summary>
+        /// Type.
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Value.
+        /// </summary>
+        public decimal Value { get; set; }
+
+    }
+}

--- a/src/MercadoPago/Client/Payment/PaymentMethodRequest.cs
+++ b/src/MercadoPago/Client/Payment/PaymentMethodRequest.cs
@@ -1,0 +1,16 @@
+namespace MercadoPago.Client.Payment
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Payment method.
+    /// </summary>
+    public class PaymentMethodRequest
+    {
+        /// <summary>
+        /// Payment data.
+        /// </summary>
+        public PaymentDataRequest Data { get; set; }
+    }
+}

--- a/src/MercadoPago/Client/Payment/PaymentRulesRequest.cs
+++ b/src/MercadoPago/Client/Payment/PaymentRulesRequest.cs
@@ -4,9 +4,9 @@ namespace MercadoPago.Client.Payment
     using System.Collections.Generic;
 
     /// <summary>
-    /// Payment's ticket info.
+    /// Payment's rules.
     /// </summary>
-    public class PaymentTicketInfoRequest
+    public class PaymentRulesRequest
     {
 
         /// <summary>

--- a/src/MercadoPago/Client/Payment/PaymentTicketInfoRequest.cs
+++ b/src/MercadoPago/Client/Payment/PaymentTicketInfoRequest.cs
@@ -1,0 +1,27 @@
+namespace MercadoPago.Client.Payment
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Payment's ticket info.
+    /// </summary>
+    public class PaymentTicketInfoRequest
+    {
+
+        /// <summary>
+        /// Discounts.
+        /// </summary>
+        public IList<PaymentDiscountRequest> Discounts { get; set; }
+
+        /// <summary>
+        /// Fine.
+        /// </summary>
+        public PaymentFeeRequest Fine { get; set; }
+
+        /// <summary>
+        /// Interest.
+        /// </summary>
+        public PaymentFeeRequest Interest { get; set; }
+    }
+}

--- a/src/MercadoPago/Client/Payment/PaymentTransactionDataRequest.cs
+++ b/src/MercadoPago/Client/Payment/PaymentTransactionDataRequest.cs
@@ -37,10 +37,5 @@ namespace MercadoPago.Client.Payment
         /// Billing date.
         /// </summary>
         public string BillingDate { get; set; }
-
-        /// <summary>
-        /// Ticket info.
-        /// </summary>
-        public PaymentTicketInfoRequest TicketInfo { get; set; }
     }
 }

--- a/src/MercadoPago/Client/Payment/PaymentTransactionDataRequest.cs
+++ b/src/MercadoPago/Client/Payment/PaymentTransactionDataRequest.cs
@@ -33,10 +33,14 @@ namespace MercadoPago.Client.Payment
         /// </summary>
         public PaymentPaymentReferenceRequest PaymentReference { get; set; }
 
-         /// <summary>
+        /// <summary>
         /// Billing date.
         /// </summary>
         public string BillingDate { get; set; }
 
+        /// <summary>
+        /// Ticket info.
+        /// </summary>
+        public PaymentTicketInfoRequest TicketInfo { get; set; }
     }
 }

--- a/src/MercadoPago/Resource/Payment/Payment.cs
+++ b/src/MercadoPago/Resource/Payment/Payment.cs
@@ -266,5 +266,10 @@
         /// Response from API.
         /// </summary>
         public MercadoPagoResponse ApiResponse { get; set; }
+
+        /// <summary>
+        /// Payment method.
+        /// </summary>
+        public PaymentMethod PaymentMethod { get; set; }
     }
 }

--- a/src/MercadoPago/Resource/Payment/PaymentData.cs
+++ b/src/MercadoPago/Resource/Payment/PaymentData.cs
@@ -1,0 +1,16 @@
+namespace MercadoPago.Resource.Payment
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Payment's data.
+    /// </summary>
+    public class PaymentData
+    {
+        /// <summary>
+        /// Payment data.
+        /// </summary>
+        public PaymentRules Rules { get; set; }
+    }
+}

--- a/src/MercadoPago/Resource/Payment/PaymentData.cs
+++ b/src/MercadoPago/Resource/Payment/PaymentData.cs
@@ -9,7 +9,7 @@ namespace MercadoPago.Resource.Payment
     public class PaymentData
     {
         /// <summary>
-        /// Payment data.
+        /// Payment rules.
         /// </summary>
         public PaymentRules Rules { get; set; }
     }

--- a/src/MercadoPago/Resource/Payment/PaymentDiscount.cs
+++ b/src/MercadoPago/Resource/Payment/PaymentDiscount.cs
@@ -1,0 +1,28 @@
+namespace MercadoPago.Resource.Payment
+{
+    using System;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Payment's discount.
+    /// </summary>
+    public class PaymentDiscount
+    {
+
+        /// <summary>
+        /// Type.
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Value.
+        /// </summary>
+        public decimal Value { get; set; }
+
+        /// <summary>
+        /// Limit date.
+        /// </summary>
+        [JsonConverter(typeof(DateWithoutHourConverter))]
+        public DateTime LimitDate { get; set; }
+    }
+}

--- a/src/MercadoPago/Resource/Payment/PaymentFee.cs
+++ b/src/MercadoPago/Resource/Payment/PaymentFee.cs
@@ -1,0 +1,22 @@
+namespace MercadoPago.Resource.Payment
+{
+    using System;
+
+    /// <summary>
+    /// Payment's fee.
+    /// </summary>
+    public class PaymentFee
+    {
+
+        /// <summary>
+        /// Type.
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Value.
+        /// </summary>
+        public decimal Value { get; set; }
+
+    }
+}

--- a/src/MercadoPago/Resource/Payment/PaymentMethod.cs
+++ b/src/MercadoPago/Resource/Payment/PaymentMethod.cs
@@ -1,0 +1,16 @@
+namespace MercadoPago.Resource.Payment
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Payment method.
+    /// </summary>
+    public class PaymentMethod
+    {
+        /// <summary>
+        /// Payment data.
+        /// </summary>
+        public PaymentData Data { get; set; }
+    }
+}

--- a/src/MercadoPago/Resource/Payment/PaymentRules.cs
+++ b/src/MercadoPago/Resource/Payment/PaymentRules.cs
@@ -1,0 +1,27 @@
+namespace MercadoPago.Resource.Payment
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Payment's rules.
+    /// </summary>
+    public class PaymentRules
+    {
+
+        /// <summary>
+        /// Discounts.
+        /// </summary>
+        public IList<PaymentDiscount> Discounts { get; set; }
+
+        /// <summary>
+        /// Fine.
+        /// </summary>
+        public PaymentFee Fine { get; set; }
+
+        /// <summary>
+        /// Interest.
+        /// </summary>
+        public PaymentFee Interest { get; set; }
+    }
+}

--- a/src/MercadoPago/Serialization/DateWithoutHourConverter.cs
+++ b/src/MercadoPago/Serialization/DateWithoutHourConverter.cs
@@ -6,7 +6,7 @@ public class DateWithoutHourConverter : JsonConverter
     public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
     {
         var date = (DateTime)value;
-        var newLookingDate = date.ToString("yyyy-MMMM-dd");
+        var newLookingDate = date.ToString("yyyy-MM-dd");
         writer.WriteValue(newLookingDate);
     }
 

--- a/src/MercadoPago/Serialization/DateWithoutHourConverter.cs
+++ b/src/MercadoPago/Serialization/DateWithoutHourConverter.cs
@@ -1,0 +1,27 @@
+using System;
+using Newtonsoft.Json;
+
+public class DateWithoutHourConverter : JsonConverter
+{
+    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    {
+        var date = (DateTime)value;
+        var newLookingDate = date.ToString("yyyy-MMMM-dd");
+        writer.WriteValue(newLookingDate);
+    }
+
+    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+    {
+        throw new NotImplementedException("Unnecessary because CanRead is false. The type will skip the converter.");
+    }
+
+    public override bool CanRead
+    {
+        get { return false; }
+    }
+
+    public override bool CanConvert(Type objectType)
+    {
+        return objectType == typeof(DateTime);
+    }
+}


### PR DESCRIPTION
Para possibilitar a criação de Boleto com juros, multa e desconto através da SDK, necessitamos adicionar os campos que configuram esses parâmetros na requisição à API de Payments.

Os campos necessários são:

Requisição em JSON:

```
{
  ...
  "point_of_interaction": {
    ...
    "transaction_data": {
      ...
      "ticket_info": {
        "discounts": [{
          "value": 1.4,
          "type": "percentage",
          "limit_date": "2022-08-05"
        }],
        "fine": {
          "value": 3,
          "type": "fixed"
        },
        "interest": {
          "value": 0.03,
          "type": "percentage",        
        }
      }
    }
  }
}
```

Resposta da requisição
```

"point_of_interaction": {
   "transaction_data": {
      "ticket_info": {
            "discounts": [
              {
                  "type": "fixed",
                  "value": 5,
                  "limit_date": "2022-09-30",
                  "amount_applied": 5
              }
          ],
          "fine": {
              "type": "fixed",
              "value": 2,
              "amount_applied": 2
          },
          "interest": {
              "type": "fixed",
              "value": 0.03,
              "amount_applied": 0.03
          }
      }
   }
}
```