### PR TITLE
Support authorized_payments api

### DIFF
--- a/src/MercadoPago/Client/AuthorizedPayment/AuthorizedPaymentClient.cs
+++ b/src/MercadoPago/Client/AuthorizedPayment/AuthorizedPaymentClient.cs
@@ -9,7 +9,7 @@ namespace MercadoPago.Client.AuthorizedPayment
     using MercadoPago.Serialization;
 
     /// <summary>
-    /// Client that use the Preapproval APIs.
+    /// Client that use the Authorized Payments (also known as Invoices) APIs.
     /// </summary>
     public class AuthorizedPaymentClient : MercadoPagoClient<AuthorizedPayment>
     {
@@ -56,12 +56,12 @@ namespace MercadoPago.Client.AuthorizedPayment
         }
 
         /// <summary>
-        /// Get async a Preapproval by your ID.
+        /// Gets an AuthorizedPayment by ID.
         /// </summary>
-        /// <param name="id">The Preapproval ID.</param>
+        /// <param name="id">The AuthorizedPayment ID.</param>
         /// <param name="requestOptions"><see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A task whose the result is the Preapproval.</returns>
+        /// <returns>A task whose the result is the AuthorizedPayment.</returns>
         /// <exception cref="MercadoPagoException">If a unexpected exception occurs.</exception>
         /// <exception cref="MercadoPagoApiException">If the API returns a error.</exception>
         public Task<AuthorizedPayment> GetAsync(
@@ -73,11 +73,11 @@ namespace MercadoPago.Client.AuthorizedPayment
         }
 
         /// <summary>
-        /// Get a Preapproval by your ID.
+        /// Gets an AuthorizedPayment by ID.
         /// </summary>
-        /// <param name="id">The Preapproval ID.</param>
+        /// <param name="id">The AuthorizedPayment ID.</param>
         /// <param name="requestOptions"><see cref="RequestOptions"/></param>
-        /// <returns>The Preapproval.</returns>
+        /// <returns>The AuthorizedPayment.</returns>
         /// <exception cref="MercadoPagoException">If a unexpected exception occurs.</exception>
         /// <exception cref="MercadoPagoApiException">If the API returns a error.</exception>
         public AuthorizedPayment Get(
@@ -88,12 +88,12 @@ namespace MercadoPago.Client.AuthorizedPayment
         }
 
         /// <summary>
-        /// Searches async for Preapprovals that match the criteria of <see cref="AdvancedSearchRequest"/>.
+        /// Searches async for AuthorizedPayment that match the criteria of <see cref="AdvancedSearchRequest"/>.
         /// </summary>
         /// <param name="request">The search request parameters.</param>
         /// <param name="requestOptions"><see cref="RequestOptions"/>.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A task whose the result is a page of Preapprovals.</returns>
+        /// <returns>A task whose result is a page of AuthorizedPayments.</returns>
         /// <exception cref="MercadoPagoException">If a unexpected exception occurs.</exception>
         /// <exception cref="MercadoPagoApiException">If the API returns a error.</exception>
         public Task<ResultsResourcesPage<AuthorizedPayment>> SearchAsync(
@@ -109,11 +109,11 @@ namespace MercadoPago.Client.AuthorizedPayment
         }
 
         /// <summary>
-        /// Searches for Preapprovals that match the criteria of <see cref="AdvancedSearchRequest"/>.
+        /// Searches for AuthorizedPayment that match the criteria of <see cref="AdvancedSearchRequest"/>.
         /// </summary>
         /// <param name="request">The search request parameters.</param>
         /// <param name="requestOptions"><see cref="RequestOptions"/>.</param>
-        /// <returns>A page of Preapprovals.</returns>
+        /// <returns>A page of AuthorizedPayment.</returns>
         /// <exception cref="MercadoPagoException">If a unexpected exception occurs.</exception>
         /// <exception cref="MercadoPagoApiException">If the API returns a error.</exception>
         public ResultsResourcesPage<AuthorizedPayment> Search(

--- a/src/MercadoPago/Client/AuthorizedPayment/AuthorizedPaymentClient.cs
+++ b/src/MercadoPago/Client/AuthorizedPayment/AuthorizedPaymentClient.cs
@@ -1,0 +1,129 @@
+namespace MercadoPago.Client.AuthorizedPayment
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using MercadoPago.Error;
+    using MercadoPago.Http;
+    using MercadoPago.Resource;
+    using MercadoPago.Resource.AuthorizedPayment;
+    using MercadoPago.Serialization;
+
+    /// <summary>
+    /// Client that use the Preapproval APIs.
+    /// </summary>
+    public class AuthorizedPaymentClient : MercadoPagoClient<AuthorizedPayment>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthorizedPaymentClient"/> class.
+        /// </summary>
+        /// <param name="httpClient">The http client that will be used in HTTP requests.</param>
+        /// <param name="serializer">
+        /// The serializer that will be used to serialize the HTTP requests content
+        /// and to deserialize the HTTP response content.
+        /// </param>
+        public AuthorizedPaymentClient(IHttpClient httpClient, ISerializer serializer)
+            : base(httpClient, serializer)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthorizedPaymentClient"/> class.
+        /// </summary>
+        /// <param name="httpClient">The http client that will be used in HTTP requests.</param>
+        public AuthorizedPaymentClient(IHttpClient httpClient)
+            : this(httpClient, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthorizedPaymentClient"/> class.
+        /// </summary>
+        /// <param name="serializer">
+        /// The serializer that will be used to serialize the HTTP requests content
+        /// and to deserialize the HTTP response content.
+        /// </param>
+        public AuthorizedPaymentClient(ISerializer serializer)
+            : this(null, serializer)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthorizedPaymentClient"/> class.
+        /// </summary>
+        public AuthorizedPaymentClient()
+            : this(null, null)
+        {
+        }
+
+        /// <summary>
+        /// Get async a Preapproval by your ID.
+        /// </summary>
+        /// <param name="id">The Preapproval ID.</param>
+        /// <param name="requestOptions"><see cref="RequestOptions"/></param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A task whose the result is the Preapproval.</returns>
+        /// <exception cref="MercadoPagoException">If a unexpected exception occurs.</exception>
+        /// <exception cref="MercadoPagoApiException">If the API returns a error.</exception>
+        public Task<AuthorizedPayment> GetAsync(
+            long id,
+            RequestOptions requestOptions = null,
+            CancellationToken cancellationToken = default)
+        {
+            return SendAsync($"/authorized_payments/{id}", HttpMethod.GET, null, requestOptions, cancellationToken);
+        }
+
+        /// <summary>
+        /// Get a Preapproval by your ID.
+        /// </summary>
+        /// <param name="id">The Preapproval ID.</param>
+        /// <param name="requestOptions"><see cref="RequestOptions"/></param>
+        /// <returns>The Preapproval.</returns>
+        /// <exception cref="MercadoPagoException">If a unexpected exception occurs.</exception>
+        /// <exception cref="MercadoPagoApiException">If the API returns a error.</exception>
+        public AuthorizedPayment Get(
+            long id,
+            RequestOptions requestOptions = null)
+        {
+            return Send($"/authorized_payments/{id}", HttpMethod.GET, null, requestOptions);
+        }
+
+        /// <summary>
+        /// Searches async for Preapprovals that match the criteria of <see cref="AdvancedSearchRequest"/>.
+        /// </summary>
+        /// <param name="request">The search request parameters.</param>
+        /// <param name="requestOptions"><see cref="RequestOptions"/>.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A task whose the result is a page of Preapprovals.</returns>
+        /// <exception cref="MercadoPagoException">If a unexpected exception occurs.</exception>
+        /// <exception cref="MercadoPagoApiException">If the API returns a error.</exception>
+        public Task<ResultsResourcesPage<AuthorizedPayment>> SearchAsync(
+            SearchRequest request,
+            RequestOptions requestOptions = null,
+            CancellationToken cancellationToken = default)
+        {
+            return SearchAsync<ResultsResourcesPage<AuthorizedPayment>>(
+                "/authorized_payments/search",
+                request,
+                requestOptions,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Searches for Preapprovals that match the criteria of <see cref="AdvancedSearchRequest"/>.
+        /// </summary>
+        /// <param name="request">The search request parameters.</param>
+        /// <param name="requestOptions"><see cref="RequestOptions"/>.</param>
+        /// <returns>A page of Preapprovals.</returns>
+        /// <exception cref="MercadoPagoException">If a unexpected exception occurs.</exception>
+        /// <exception cref="MercadoPagoApiException">If the API returns a error.</exception>
+        public ResultsResourcesPage<AuthorizedPayment> Search(
+            SearchRequest request,
+            RequestOptions requestOptions = null)
+        {
+            return Search<ResultsResourcesPage<AuthorizedPayment>>(
+                "/authorized_payments/search",
+                request,
+                requestOptions);
+        }
+    }
+}

--- a/src/MercadoPago/Resource/AuthorizedPayment/AuthorizedPayment.cs
+++ b/src/MercadoPago/Resource/AuthorizedPayment/AuthorizedPayment.cs
@@ -1,0 +1,105 @@
+namespace MercadoPago.Resource.AuthorizedPayment
+{
+    using System;
+    using MercadoPago.Http;
+
+    /// <summary>
+    /// Authorized Payment resource (also known as Invoice).
+    /// </summary>
+    /// <remarks>
+    /// For more information check the documentation
+    /// <a href="https://www.mercadopago.com.br/developers/en/reference/subscriptions/resource/">here</a>
+    /// </remarks>
+    public class AuthorizedPayment : IResource
+    {
+        /// <summary>
+        /// Unique invoice identifier.
+        /// </summary>
+        public long? Id { get; set; }
+
+        /// <summary>
+        /// Type of invoice generated based on recurrence.
+        /// <list type="bullet">
+        ///   <item><c>scheduled</c>: Automatically generated and scheduled by the recurrence engine</item>
+        /// </list>
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Creation date.
+        /// </summary>
+        public DateTime? DateCreated { get; set; }
+
+        /// <summary>
+        /// Last modified date.
+        /// </summary>
+        public DateTime? LastModified { get; set; }
+
+        /// <summary>
+        /// Subscription ID for which the invoice was created.
+        /// </summary>
+        public string PreapprovalId { get; set; }
+
+        /// <summary>
+        /// It is a short description that the subscriber will see during the checkout process and in the notifications.
+        /// </summary>
+        public string Reason { get; set; }
+
+        /// <summary>
+        /// Reference to sync with your system. This is a free text field to help you with your integration to link the entities.
+        /// </summary>
+        public string ExternalReference { get; set; }
+
+        /// <summary>
+        /// ID of the currency used in the payment.
+        /// <list type="bullet">
+        ///   <item><c>ARS</c>: Argentine peso.</item>
+        ///   <item><c>BRL</c>: Brazilian real.</item>
+        ///   <item><c>CLP</c>: Chilean peso.</item>
+        ///   <item><c>MXN</c>: Mexican peso.</item>
+        ///   <item><c>COP</c>: Colombian peso.</item>
+        ///   <item><c>PEN</c>: Peruvian sol.</item>
+        ///   <item><c>UYU</c>: Uruguayan peso.</item>
+        /// </list>
+        /// </summary>
+        public string CurrencyId { get; set; }
+
+        /// <summary>
+        /// Amount we will charge on each invoice.
+        /// </summary>
+        public decimal TransactionAmount { get; set; }
+
+        /// <summary>
+        /// Date on which we will try to make the payment.
+        /// </summary>
+        public DateTime? DebitDate { get; set; }
+
+        /// <summary>
+        /// How many times we try to collect the invoice.
+        /// </summary>
+        public int? RetryAttempt { get; set; }
+
+        /// <summary>
+        /// Summarization status of the invoice result in the subscription.
+        /// <list type="bullet">
+        ///   <item><c>pending</c>: Pending summary in the subscription.</item>
+        ///   <item><c>done</c>: Summarized result in the subscription</item>
+        /// </list>
+        /// </summary>
+        public string Summarized { get; set; }
+
+        /// <summary>
+        /// Summarization status of the invoice result in the subscription.
+        /// <list type="bullet">
+        ///   <item><c>pending</c>: Pending summary in the subscription.</item>
+        ///   <item><c>done</c>: Summarized result in the subscription</item>
+        /// </list>
+        /// </summary>
+        public AuthorizedPaymentPayment Payment { get; set; }
+
+        /// <summary>
+        /// Response from API.
+        /// </summary>
+        public MercadoPagoResponse ApiResponse { get; set; }
+    }
+}

--- a/src/MercadoPago/Resource/AuthorizedPayment/AuthorizedPaymentPayment.cs
+++ b/src/MercadoPago/Resource/AuthorizedPayment/AuthorizedPaymentPayment.cs
@@ -1,0 +1,36 @@
+namespace MercadoPago.Resource.AuthorizedPayment
+{
+    using System;
+
+    /// <summary>
+    /// Payment status related to the invoice.
+    /// </summary>
+    public class AuthorizedPaymentPayment
+    {
+        /// <summary>
+        /// Unique payment identifier.
+        /// </summary>
+        public long? Id { get; set; }
+
+        /// <summary>
+        /// Payment status.
+        /// <list type="bullet">
+        ///   <item><c>pending</c>: The user has not yet completed the payment process</item>
+        ///   <item><c>approved</c>: The payment has been approved and accredited</item>
+        ///   <item><c>authorized</c>: The payment has been authorized but not captured yet</item>
+        ///   <item><c>in_process</c>: Payment is being reviewed</item>
+        ///   <item><c>in_mediation</c>: Users have initiated a dispute</item>
+        ///   <item><c>rejected</c>: Payment was rejected. The user may retry payment</item>
+        ///   <item><c>cancelled</c>: Payment was cancelled by one of the parties or because time for payment has expired</item>
+        ///   <item><c>refunded</c>: Payment was refunded to the user</item>
+        ///   <item><c>charged_back</c>: Was made a chargeback in the buyer’s credit card</item>
+        /// </list>
+        /// </summary>
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Payment status detail.
+        /// </summary>
+        public string StatusDetail { get; set; }
+    }
+}


### PR DESCRIPTION
Added client and data model for the authorized_payments (also known as Invoices) api.

This change is missing unit tests since the repo did not provide enough information on how to run unit tests locally.

NOTE: You have the `Issues` tab disabled for this repo, preventing people from engaging with your dev team. Please see: [Disabling issues - Github](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/disabling-issues)