### PR TITLE
Add method to create oauth credentials using client id/client secret

### DIFF
--- a/src/MercadoPago/Client/OAuth/CreateOAuthCredentialRequest.cs
+++ b/src/MercadoPago/Client/OAuth/CreateOAuthCredentialRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace MercadoPago.Client.OAuth
+namespace MercadoPago.Client.OAuth
 {
     /// <summary>
     /// Data to create an OAuth credential.
@@ -6,7 +6,12 @@
     public class CreateOAuthCredentialRequest
     {
         /// <summary>
-        /// Client secret (Access Token).
+        /// Client Id
+        /// </summary>
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// Client secret
         /// </summary>
         public string ClientSecret { get; set; }
 

--- a/src/MercadoPago/Client/OAuth/OAuthClient.cs
+++ b/src/MercadoPago/Client/OAuth/OAuthClient.cs
@@ -122,9 +122,51 @@ namespace MercadoPago.Client.OAuth
                 .Append(redirectUri)
                 .ToString();
         }
+        /// <summary>
+        /// Creates an OAuth credentials asynchronously using
+        /// access token as client secret.
+        /// </summary>
+        /// <param name="authorizationCode">Authorization code.</param>
+        /// <param name="redirectUri">Redirect Uri.</param>
+        /// <param name="requestOptions"><see cref="RequestOptions"/>.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A task whose the result is the OAuth credential.</returns>
+        /// <exception cref="MercadoPagoException">If a unexpected exception occurs.</exception>
+        /// <exception cref="MercadoPagoApiException">If the API returns a error.</exception>
+        public Task<OAuthCredential> CreateOAuthCredentialAsync(
+            string authorizationCode,
+            string redirectUri,
+            RequestOptions requestOptions = null,
+            CancellationToken cancellationToken = default)
+        {
+            string accessToken;
+            if (requestOptions != null)
+            {
+                accessToken = string.IsNullOrWhiteSpace(requestOptions.AccessToken) ?
+                    MercadoPagoConfig.AccessToken : requestOptions.AccessToken;
+            }
+            else
+            {
+                accessToken = MercadoPagoConfig.AccessToken;
+            }
+
+            var request = new CreateOAuthCredentialRequest
+            {
+                ClientSecret = accessToken,
+                Code = authorizationCode,
+                RedirectUri = redirectUri,
+            };
+            return SendAsync(
+                "/oauth/token",
+                HttpMethod.POST,
+                request,
+                requestOptions,
+                cancellationToken);
+        }
 
         /// <summary>
-        /// Creates async an OAuth credentials.
+        /// Creates an OAuth credentials asynchronously with
+        /// client id and client secret.
         /// </summary>
         /// <param name="authorizationCode">Authorization code.</param>
         /// <param name="clientId">Client Id.</param>
@@ -159,7 +201,47 @@ namespace MercadoPago.Client.OAuth
         }
 
         /// <summary>
-        /// Creates an OAuth credentials.
+        /// Creates an OAuth credentials using
+        /// access token as client secret.
+        /// </summary>
+        /// <param name="authorizationCode">Authorization code.</param>
+        /// <param name="redirectUri">Redirect Uri.</param>
+        /// <param name="requestOptions"><see cref="RequestOptions"/>.</param>
+        /// <returns>The OAuth credential.</returns>
+        /// <exception cref="MercadoPagoException">If a unexpected exception occurs.</exception>
+        /// <exception cref="MercadoPagoApiException">If the API returns a error.</exception>
+        public OAuthCredential CreateOAuthCredential(
+            string authorizationCode,
+            string redirectUri,
+            RequestOptions requestOptions = null)
+        {
+            string accessToken;
+            if (requestOptions != null)
+            {
+                accessToken = string.IsNullOrWhiteSpace(requestOptions.AccessToken) ?
+                    MercadoPagoConfig.AccessToken : requestOptions.AccessToken;
+            }
+            else
+            {
+                accessToken = MercadoPagoConfig.AccessToken;
+            }
+
+            var request = new CreateOAuthCredentialRequest
+            {
+                ClientSecret = accessToken,
+                Code = authorizationCode,
+                RedirectUri = redirectUri,
+            };
+            return Send(
+                "/oauth/token",
+                HttpMethod.POST,
+                request,
+                requestOptions);
+        }
+
+        /// <summary>
+        /// Creates an OAuth credentials with
+        /// client id and client secret.
         /// </summary>
         /// <param name="authorizationCode">Authorization code.</param>
         /// <param name="clientId">Client Id.</param>

--- a/src/MercadoPago/Client/OAuth/OAuthClient.cs
+++ b/src/MercadoPago/Client/OAuth/OAuthClient.cs
@@ -1,4 +1,4 @@
-﻿namespace MercadoPago.Client.OAuth
+namespace MercadoPago.Client.OAuth
 {
     using System.Text;
     using System.Threading;
@@ -127,6 +127,8 @@
         /// Creates async an OAuth credentials.
         /// </summary>
         /// <param name="authorizationCode">Authorization code.</param>
+        /// <param name="clientId">Client Id.</param>
+        /// <param name="clientSecret">Client Secret.</param>
         /// <param name="redirectUri">Redirect Uri.</param>
         /// <param name="requestOptions"><see cref="RequestOptions"/>.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
@@ -135,24 +137,16 @@
         /// <exception cref="MercadoPagoApiException">If the API returns a error.</exception>
         public Task<OAuthCredential> CreateOAuthCredentialAsync(
             string authorizationCode,
+            string clientId,
+            string clientSecret,
             string redirectUri,
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            string accessToken;
-            if (requestOptions != null)
-            {
-                accessToken = string.IsNullOrWhiteSpace(requestOptions.AccessToken) ?
-                    MercadoPagoConfig.AccessToken : requestOptions.AccessToken;
-            }
-            else
-            {
-                accessToken = MercadoPagoConfig.AccessToken;
-            }
-
             var request = new CreateOAuthCredentialRequest
             {
-                ClientSecret = accessToken,
+                ClientId = clientId,
+                ClientSecret = clientSecret,
                 Code = authorizationCode,
                 RedirectUri = redirectUri,
             };
@@ -168,6 +162,8 @@
         /// Creates an OAuth credentials.
         /// </summary>
         /// <param name="authorizationCode">Authorization code.</param>
+        /// <param name="clientId">Client Id.</param>
+        /// <param name="clientSecret">Client Secret.</param>
         /// <param name="redirectUri">Redirect Uri.</param>
         /// <param name="requestOptions"><see cref="RequestOptions"/>.</param>
         /// <returns>The OAuth credential.</returns>
@@ -175,23 +171,15 @@
         /// <exception cref="MercadoPagoApiException">If the API returns a error.</exception>
         public OAuthCredential CreateOAuthCredential(
             string authorizationCode,
+            string clientId,
+            string clientSecret,
             string redirectUri,
             RequestOptions requestOptions = null)
         {
-            string accessToken;
-            if (requestOptions != null)
-            {
-                accessToken = string.IsNullOrWhiteSpace(requestOptions.AccessToken) ?
-                    MercadoPagoConfig.AccessToken : requestOptions.AccessToken;
-            }
-            else
-            {
-                accessToken = MercadoPagoConfig.AccessToken;
-            }
-
             var request = new CreateOAuthCredentialRequest
             {
-                ClientSecret = accessToken,
+                ClientId = clientId,
+                ClientSecret = clientSecret,
                 Code = authorizationCode,
                 RedirectUri = redirectUri,
             };


### PR DESCRIPTION
This branch includes the changes made at #168, refactoring it as an overloaded method to keep the original method as a separate way of using credentials using the access token as client secret.