### PR TITLE
feat: added industry fields

### DIFF
--- a/src/MercadoPago.Tests/Client/AdvancedPayment/AdvancedPaymentClientTest.cs
+++ b/src/MercadoPago.Tests/Client/AdvancedPayment/AdvancedPaymentClientTest.cs
@@ -340,7 +340,7 @@
                     Address = new AddressRequest
                     {
                         StreetName = "Street",
-                        StreetNumber = "120",
+                        StreetNumber = 120,
                     },
                     Identification = IdentificationHelper.GetIdentification(User),
                 },
@@ -359,7 +359,7 @@
                         Address = new AddressRequest
                         {
                             StreetName = "Street",
-                            StreetNumber = "120",
+                            StreetNumber = 120,
                         },
                         Phone = new PhoneRequest
                         {

--- a/src/MercadoPago.Tests/Client/AdvancedPayment/AdvancedPaymentClientTest.cs
+++ b/src/MercadoPago.Tests/Client/AdvancedPayment/AdvancedPaymentClientTest.cs
@@ -385,7 +385,7 @@
                         ReceiverAddress = new AdvancedPaymentReceiverAddressRequest
                         {
                             StreetName = "Street",
-                            StreetNumber = "120",
+                            StreetNumber = 120,
                             Floor = "1",
                             Apartment = "A",
                         },

--- a/src/MercadoPago.Tests/Client/Payment/PaymentClientTest.cs
+++ b/src/MercadoPago.Tests/Client/Payment/PaymentClientTest.cs
@@ -546,7 +546,7 @@
                         Address = new AddressRequest
                         {
                             StreetName = "Street",
-                            StreetNumber = "123",
+                            StreetNumber = 123,
                         },
                         AuthenticationType = "None",
                         IsFirstPurchaseOnline = false,
@@ -558,7 +558,7 @@
                         ReceiverAddress = new PaymentReceiverAddressRequest
                         {
                             StreetName = "Street",
-                            StreetNumber = "123",
+                            StreetNumber = 123,
                             Apartment = "23",
                             Floor = "First",
                             CityName = "City",

--- a/src/MercadoPago.Tests/Client/Preference/PreferenceClientTest.cs
+++ b/src/MercadoPago.Tests/Client/Preference/PreferenceClientTest.cs
@@ -223,7 +223,7 @@
                     Address = new AddressRequest
                     {
                         StreetName = "Street",
-                        StreetNumber = "123",
+                        StreetNumber = 123,
                     },
                 },
                 PaymentMethods = new PreferencePaymentMethodsRequest
@@ -253,7 +253,8 @@
                     Dimensions = "10x10x20,500",
                     ReceiverAddress = new PreferenceReceiverAddressRequest
                     {
-                        StreetNumber = "123",
+                        ZipCode = "00000-000",
+                        StreetNumber = 123,
                         StreetName = "Street",
                         Floor = "12",
                         Apartment = "120A",

--- a/src/MercadoPago/Client/Common/AddressRequest.cs
+++ b/src/MercadoPago/Client/Common/AddressRequest.cs
@@ -18,6 +18,6 @@
         /// <summary>
         /// Number.
         /// </summary>
-        public string StreetNumber { get; set; }
+        public int StreetNumber { get; set; }
     }
 }

--- a/src/MercadoPago/Client/Preference/PreferencePayerRequest.cs
+++ b/src/MercadoPago/Client/Preference/PreferencePayerRequest.cs
@@ -62,5 +62,10 @@
         /// Date of the last purchase.
         /// </summary>
         public DateTime? LastPurchase { get; set; }
+
+        /// <summary>
+        /// Date of registration.
+        /// </summary>
+        public DateTime? RegistrationDate { get; set; }
     }
 }


### PR DESCRIPTION
Adding industry fields.
Some fields already existed and were mapped as if they didn't. 

[spreadsheet with dotnet SDK fields](https://docs.google.com/spreadsheets/d/18pe_0PYN7rOXd5EnNGisWqTQviabCiekt5i2D78F0Dk/edit?gid=57869768#gid=57869768) (noted the fields that already exist and where they are)

StreetNumber is now int
<img width="745" alt="Captura de Tela 2025-04-29 às 15 58 41" src="https://github.com/user-attachments/assets/75c81425-61da-4444-8a14-7e89e35baabc" />

CI errors are a mapped bug: [TASK](https://mercadolibre.atlassian.net/browse/PUBLICAPI-2355)