### PR TITLE
[feature] adding order industry fields

### DIFF
--- a/src/MercadoPago/Client/Order/OrderCreateRequest.cs
+++ b/src/MercadoPago/Client/Order/OrderCreateRequest.cs
@@ -82,5 +82,10 @@ namespace MercadoPago.Client.Order
         /// Configuration.
         /// </summary>
         public OrderConfigRequest Config { get; set; }
+
+        /// <summary>
+        /// Additional info for the order.
+        /// </summary>
+        public IDictionary<string, object> AdditionalInfo { get; set; }
     }
 }

--- a/src/MercadoPago/Client/Order/OrderItemsRequest.cs
+++ b/src/MercadoPago/Client/Order/OrderItemsRequest.cs
@@ -33,6 +33,11 @@ namespace MercadoPago.Client.Order
         public string CategoryId { get; set; }
 
         /// <summary>
+        /// Type of the item.
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
         /// Description of the item.
         /// </summary>
         public string Description { get; set; }
@@ -41,5 +46,15 @@ namespace MercadoPago.Client.Order
         /// Picture URL of the item.
         /// </summary>
         public string PictureUrl { get; set; }
+
+        /// <summary>
+        /// Warranty of the item.
+        /// </summary>
+        public bool? Warranty { get; set; }
+
+        /// <summary>
+        /// Event date of the item.
+        /// </summary>
+        public string EventDate { get; set; }
     }
 }

--- a/src/MercadoPago/Client/Order/OrderPayerRequest.cs
+++ b/src/MercadoPago/Client/Order/OrderPayerRequest.cs
@@ -13,6 +13,11 @@ namespace MercadoPago.Client.Order
         public string Email { get; set; }
 
         /// <summary>
+        /// Payer's entity type.
+        /// </summary>
+        public string EntityType { get; set; }
+
+        /// <summary>
         /// Payer's first name.
         /// </summary>
         public string FirstName { get; set; }

--- a/src/MercadoPago/Resource/Order/Order.cs
+++ b/src/MercadoPago/Resource/Order/Order.cs
@@ -129,5 +129,10 @@ namespace MercadoPago.Resource.Order
         /// Response from API.
         /// </summary>
         public MercadoPagoResponse ApiResponse { get; set; }
+
+        /// <summary>
+        /// Additional info for the order.
+        /// </summary>
+        public IDictionary<string, object> AdditionalInfo { get; set; }
     }
 }

--- a/src/MercadoPago/Resource/Order/OrderItems.cs
+++ b/src/MercadoPago/Resource/Order/OrderItems.cs
@@ -41,5 +41,15 @@ namespace MercadoPago.Resource.Order
         /// Quantity of the item.
         /// </summary>
         public int? Quantity { get; set; }
+
+        /// <summary>
+        /// Warranty of the item.
+        /// </summary>
+        public bool? Warranty { get; set; }
+
+        /// <summary>
+        /// Event date of the item.
+        /// </summary>
+        public string EventDate { get; set; }
     }
 }


### PR DESCRIPTION
[Orders DOC](https://web.furycloud.io/mp-public-order-api/specs-hub/spec/acd67b14-97c4-4a4a-840d-0a018c09654f)

- Added AdditionalInfo field to /src/MercadoPago/Resource/Order/Order.cs as IDictionary<string, object>
- Added AdditionalInfo field to /src/MercadoPago/Client/Order/OrderCreateRequest.cs as IDictionary<string, object>
- Added support for industry fields in additional_info in OrderCreateRequest.cs and Order.cs
- Added support for platform seller information in OrderCreateRequest.cs and Order.cs
- Added support for payer additional attributes in OrderCreateRequest.cs and Order.cs
- Added support for shipment additional data in OrderCreateRequest.cs and Order.cs