### PR TITLE
[Docs] Update credential panel link in README files

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -49,7 +49,7 @@ nuget install mercadopago-sdk
 
 ¿Primera vez usando Mercado Pago? Crea tu [cuenta de Mercado Pago](https://www.mercadopago.com).
 
-Copie su `Access Token` del [panel de credenciales](https://www.mercadopago.com/developers/panel/credentials) y reemplace el texto `YOUR_ACCESS_TOKEN` con él.
+Copie su `Access Token` del [panel de credenciales](https://www.mercadopago.com/developers/panel/app) y reemplace el texto `YOUR_ACCESS_TOKEN` con él.
 
 ### Uso simple
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ nuget install mercadopago-sdk
 
 First time using Mercado Pago? Create your [Mercado Pago account](https://www.mercadopago.com).
 
-Copy your `Access Token` in the [credentials panel](https://www.mercadopago.com/developers/panel/credentials) and replace the text `YOUR_ACCESS_TOKEN` with it.
+Copy your `Access Token` in the [credentials panel](https://www.mercadopago.com/developers/panel/app) and replace the text `YOUR_ACCESS_TOKEN` with it.
 
 ### Simple usage
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -49,7 +49,7 @@ nuget install mercadopago-sdk
 
 Primeira vez usando o Mercado Pago? Crie sua [conta do Mercado Pago](https://www.mercadopago.com).
 
-Copie seu `Access Token` do [painel de credenciais](https://www.mercadopago.com/developers/panel/credentials) e substitua o texto `YOUR_ACCESS_TOKEN` com ele.
+Copie seu `Access Token` do [painel de credenciais](https://www.mercadopago.com/developers/panel/app) e substitua o texto `YOUR_ACCESS_TOKEN` com ele.
 
 ### Uso simples
 


### PR DESCRIPTION
The old link to the credentials panel (https://www.mercadopago.com/developers/panel/credentials) is currently broken — it returns the message "Lo sentimos, lo que querías ver no existe o lo movimos de lugar."

I found the new working link (https://www.mercadopago.com/developers/panel/app) and updated it in the documentation. I've applied this fix to the English, Spanish, and Portuguese README files to keep them consistent.

Let me know if further adjustments are needed.