### PR TITLE
Add WebhookSignatureValidator utility

### DIFF
--- a/src/MercadoPago.Tests/Webhook/WebhookSignatureValidatorTest.cs
+++ b/src/MercadoPago.Tests/Webhook/WebhookSignatureValidatorTest.cs
@@ -1,0 +1,237 @@
+﻿namespace MercadoPago.Tests.Webhook
+{
+    using System;
+    using System.Security.Cryptography;
+    using System.Text;
+    using MercadoPago.Error;
+    using MercadoPago.Webhook;
+    using Xunit;
+
+    public class WebhookSignatureValidatorTest
+    {
+        private const string Secret = "your_secret_key_here";
+        private const string RequestId = "2066ca19-c6f1-498a-be75-1923005edd06";
+        private const string DataIdRaw = "ORD01JQ4S4KY8HWQ6NA5PXB65B3D3";
+        private const string DataIdLower = "ord01jq4s4ky8hwq6na5pxb65b3d3";
+
+        private static string CurrentTs() =>
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        private static string ComputeHash(string dataId, string requestId, string ts, string secret)
+        {
+            var parts = new System.Collections.Generic.List<string>(3);
+            if (!string.IsNullOrWhiteSpace(dataId))
+            {
+                parts.Add($"id:{dataId.ToLowerInvariant()}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(requestId))
+            {
+                parts.Add($"request-id:{requestId}");
+            }
+
+            parts.Add($"ts:{ts}");
+            var manifest = string.Join(";", parts) + ";";
+
+            using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+            var hashBytes = hmac.ComputeHash(Encoding.UTF8.GetBytes(manifest));
+            var sb = new StringBuilder(hashBytes.Length * 2);
+            foreach (var b in hashBytes)
+            {
+                sb.Append(b.ToString("x2", System.Globalization.CultureInfo.InvariantCulture));
+            }
+
+            return sb.ToString();
+        }
+
+        private static string BuildHeader(string hash, string ts, string version = "v1") =>
+            $"ts={ts},{version}={hash}";
+
+        // --- Canonical case 1: happy path with lowercase dataId ---
+        [Fact]
+        public void Validate_HappyPathWithLowercaseDataId_DoesNotThrow()
+        {
+            var ts = CurrentTs();
+            var hash = ComputeHash(DataIdLower, RequestId, ts, Secret);
+
+            WebhookSignatureValidator.Validate(
+                BuildHeader(hash, ts), RequestId, DataIdLower, Secret);
+        }
+
+        // --- Canonical case 2: dataId in uppercase — SDK must lowercase before HMAC ---
+        [Fact]
+        public void Validate_DataIdInUppercase_StillValidates()
+        {
+            var ts = CurrentTs();
+            var hash = ComputeHash(DataIdLower, RequestId, ts, Secret);
+
+            WebhookSignatureValidator.Validate(
+                BuildHeader(hash, ts), RequestId, DataIdRaw, Secret);
+        }
+
+        // --- Canonical case 3: malformed header (no =) ---
+        [Fact]
+        public void Validate_MalformedHeader_ThrowsMalformedSignatureHeader()
+        {
+            var ex = Assert.Throws<InvalidWebhookSignatureException>(() =>
+                WebhookSignatureValidator.Validate(
+                    "this-is-garbage", RequestId, DataIdLower, Secret));
+            Assert.Equal(SignatureFailureReason.MalformedSignatureHeader, ex.Reason);
+            Assert.Equal(RequestId, ex.RequestId);
+        }
+
+        // --- Canonical case 4: missing header ---
+        [Fact]
+        public void Validate_MissingHeader_ThrowsMissingSignatureHeader()
+        {
+            var ex = Assert.Throws<InvalidWebhookSignatureException>(() =>
+                WebhookSignatureValidator.Validate(
+                    null, RequestId, DataIdLower, Secret));
+            Assert.Equal(SignatureFailureReason.MissingSignatureHeader, ex.Reason);
+        }
+
+        // --- Canonical case 5: header has v1 but no ts ---
+        [Fact]
+        public void Validate_MissingTimestamp_ThrowsMissingTimestamp()
+        {
+            var ts = CurrentTs();
+            var hash = ComputeHash(DataIdLower, RequestId, ts, Secret);
+
+            var ex = Assert.Throws<InvalidWebhookSignatureException>(() =>
+                WebhookSignatureValidator.Validate(
+                    $"v1={hash}", RequestId, DataIdLower, Secret));
+            Assert.Equal(SignatureFailureReason.MissingTimestamp, ex.Reason);
+        }
+
+        // --- Canonical case 6: header has ts but no v1 ---
+        [Fact]
+        public void Validate_MissingV1_ThrowsMissingHash()
+        {
+            var ts = CurrentTs();
+            var ex = Assert.Throws<InvalidWebhookSignatureException>(() =>
+                WebhookSignatureValidator.Validate(
+                    $"ts={ts}", RequestId, DataIdLower, Secret));
+            Assert.Equal(SignatureFailureReason.MissingHash, ex.Reason);
+            Assert.Equal(ts, ex.Timestamp);
+        }
+
+        // --- Canonical case 7: tampered hash ---
+        [Fact]
+        public void Validate_TamperedHash_ThrowsSignatureMismatch()
+        {
+            var ts = CurrentTs();
+            var hash = ComputeHash(DataIdLower, RequestId, ts, Secret);
+            var tampered = hash[..^2] + (hash.EndsWith("00", StringComparison.Ordinal) ? "ff" : "00");
+
+            var ex = Assert.Throws<InvalidWebhookSignatureException>(() =>
+                WebhookSignatureValidator.Validate(
+                    BuildHeader(tampered, ts), RequestId, DataIdLower, Secret));
+            Assert.Equal(SignatureFailureReason.SignatureMismatch, ex.Reason);
+        }
+
+        // --- Canonical case 8: timestamp outside tolerance ---
+        [Fact]
+        public void Validate_TimestampOutsideTolerance_ThrowsTimestampOutOfTolerance()
+        {
+            var staleTs = (DateTimeOffset.UtcNow.AddMinutes(-30).ToUnixTimeMilliseconds())
+                .ToString(System.Globalization.CultureInfo.InvariantCulture);
+            var hash = ComputeHash(DataIdLower, RequestId, staleTs, Secret);
+
+            var ex = Assert.Throws<InvalidWebhookSignatureException>(() =>
+                WebhookSignatureValidator.Validate(
+                    BuildHeader(hash, staleTs), RequestId, DataIdLower, Secret,
+                    tolerance: TimeSpan.FromMinutes(5)));
+            Assert.Equal(SignatureFailureReason.TimestampOutOfTolerance, ex.Reason);
+        }
+
+        [Fact]
+        public void Validate_TimestampWithinTolerance_DoesNotThrow()
+        {
+            var ts = CurrentTs();
+            var hash = ComputeHash(DataIdLower, RequestId, ts, Secret);
+
+            WebhookSignatureValidator.Validate(
+                BuildHeader(hash, ts), RequestId, DataIdLower, Secret,
+                tolerance: TimeSpan.FromMinutes(5));
+        }
+
+        // --- Canonical case 9: data.id absent → manifest excludes id: ---
+        [Fact]
+        public void Validate_DataIdAbsent_ManifestExcludesIdPair()
+        {
+            var ts = CurrentTs();
+            var hash = ComputeHash(null, RequestId, ts, Secret);
+
+            WebhookSignatureValidator.Validate(
+                BuildHeader(hash, ts), RequestId, null, Secret);
+        }
+
+        // --- Canonical case 10: x-request-id absent → manifest excludes request-id: ---
+        [Fact]
+        public void Validate_RequestIdAbsent_ManifestExcludesRequestIdPair()
+        {
+            var ts = CurrentTs();
+            var hash = ComputeHash(DataIdLower, null, ts, Secret);
+
+            WebhookSignatureValidator.Validate(
+                BuildHeader(hash, ts), null, DataIdLower, Secret);
+        }
+
+        // --- Canonical case 11: both absent → manifest is ts: only ---
+        [Fact]
+        public void Validate_BothAbsent_ManifestIsTsOnly()
+        {
+            var ts = CurrentTs();
+            var hash = ComputeHash(null, null, ts, Secret);
+
+            WebhookSignatureValidator.Validate(
+                BuildHeader(hash, ts), string.Empty, "  ", Secret);
+        }
+
+        // --- Canonical case 12: non-payment topic uses the same algorithm ---
+        [Fact]
+        public void Validate_NonPaymentTopic_UsesSameAlgorithm()
+        {
+            const string orderDataId = "ord01abc123";
+            var ts = CurrentTs();
+            var hash = ComputeHash(orderDataId, RequestId, ts, Secret);
+
+            WebhookSignatureValidator.Validate(
+                BuildHeader(hash, ts), RequestId, orderDataId, Secret);
+        }
+
+        // --- supportedVersions: forward compatibility ---
+        [Fact]
+        public void Validate_HeaderHasV1AndV2_OnlyV1Supported_UsesV1()
+        {
+            var ts = CurrentTs();
+            var v1Hash = ComputeHash(DataIdLower, RequestId, ts, Secret);
+            var header = $"ts={ts},v1={v1Hash},v2=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+            WebhookSignatureValidator.Validate(
+                header, RequestId, DataIdLower, Secret);
+        }
+
+        [Fact]
+        public void Validate_HeaderHasOnlyV2_OnlyV1Supported_ThrowsMissingHash()
+        {
+            var ts = CurrentTs();
+            var header = $"ts={ts},v2=somehash";
+
+            var ex = Assert.Throws<InvalidWebhookSignatureException>(() =>
+                WebhookSignatureValidator.Validate(
+                    header, RequestId, DataIdLower, Secret));
+            Assert.Equal(SignatureFailureReason.MissingHash, ex.Reason);
+        }
+
+        // --- secret null guard ---
+        [Fact]
+        public void Validate_NullSecret_ThrowsArgumentNullException()
+        {
+            var ts = CurrentTs();
+            Assert.Throws<ArgumentNullException>(() =>
+                WebhookSignatureValidator.Validate(
+                    $"ts={ts},v1=abc", RequestId, DataIdLower, null));
+        }
+    }
+}

--- a/src/MercadoPago/Error/InvalidWebhookSignatureException.cs
+++ b/src/MercadoPago/Error/InvalidWebhookSignatureException.cs
@@ -1,0 +1,58 @@
+﻿namespace MercadoPago.Error
+{
+    using System;
+
+    /// <summary>
+    /// Exception thrown by <see cref="MercadoPago.Webhook.WebhookSignatureValidator"/>
+    /// when a webhook notification cannot be confirmed as originating from MercadoPago.
+    /// </summary>
+    /// <remarks>
+    /// The exception carries enough context to support structured logging without
+    /// exposing internal details in the HTTP response. The <see cref="Reason"/>
+    /// indicates why validation failed, while <see cref="RequestId"/> and
+    /// <see cref="Timestamp"/> echo the inputs that were available at the point
+    /// of failure (when applicable) to correlate against MercadoPago's
+    /// notifications dashboard.
+    /// </remarks>
+    public class InvalidWebhookSignatureException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidWebhookSignatureException"/> class.
+        /// </summary>
+        /// <param name="reason">The specific failure mode that triggered the exception.</param>
+        /// <param name="requestId">
+        /// The <c>x-request-id</c> header value associated with the request, when available.
+        /// May be <c>null</c> if the header was not provided.
+        /// </param>
+        /// <param name="timestamp">
+        /// The <c>ts</c> value extracted from the <c>x-signature</c> header, when parsing
+        /// reached that point. May be <c>null</c> if parsing failed earlier.
+        /// </param>
+        public InvalidWebhookSignatureException(
+            SignatureFailureReason reason,
+            string requestId = null,
+            string timestamp = null)
+            : base($"Invalid webhook signature: {reason}")
+        {
+            Reason = reason;
+            RequestId = requestId;
+            Timestamp = timestamp;
+        }
+
+        /// <summary>
+        /// Gets the specific failure mode that triggered the exception.
+        /// </summary>
+        public SignatureFailureReason Reason { get; }
+
+        /// <summary>
+        /// Gets the <c>x-request-id</c> header value associated with the request, when available.
+        /// </summary>
+        public string RequestId { get; }
+
+        /// <summary>
+        /// Gets the <c>ts</c> value extracted from the <c>x-signature</c> header, when parsing
+        /// reached that point.
+        /// </summary>
+        public string Timestamp { get; }
+    }
+}

--- a/src/MercadoPago/Error/SignatureFailureReason.cs
+++ b/src/MercadoPago/Error/SignatureFailureReason.cs
@@ -1,0 +1,53 @@
+﻿namespace MercadoPago.Error
+{
+    /// <summary>
+    /// Enumerates the reasons why
+    /// <see cref="MercadoPago.Webhook.WebhookSignatureValidator"/> may reject a
+    /// MercadoPago webhook notification.
+    /// </summary>
+    /// <remarks>
+    /// Each value maps to a specific failure mode in the signature verification flow.
+    /// Integrators are encouraged to log this value alongside the
+    /// <c>x-request-id</c> for correlation against the MercadoPago notifications dashboard.
+    /// </remarks>
+    public enum SignatureFailureReason
+    {
+        /// <summary>
+        /// The <c>x-signature</c> header was <c>null</c>, empty, or whitespace.
+        /// </summary>
+        MissingSignatureHeader,
+
+        /// <summary>
+        /// The <c>x-signature</c> header did not match the expected
+        /// <c>ts=...,vN=...</c> format and could not be parsed.
+        /// </summary>
+        MalformedSignatureHeader,
+
+        /// <summary>
+        /// The <c>x-signature</c> header parsed correctly but no <c>ts=</c> component
+        /// was present.
+        /// </summary>
+        MissingTimestamp,
+
+        /// <summary>
+        /// The <c>x-signature</c> header did not include a hash for any of the
+        /// versions listed in <c>supportedVersions</c>. This typically indicates that
+        /// MercadoPago has migrated to a new signature version (e.g. <c>v2</c>) and the
+        /// SDK needs to be upgraded.
+        /// </summary>
+        MissingHash,
+
+        /// <summary>
+        /// The HMAC computed locally did not match the hash provided in the header.
+        /// Most often caused by an incorrect secret signature or by a forged request.
+        /// </summary>
+        SignatureMismatch,
+
+        /// <summary>
+        /// The header timestamp was outside the configured <c>tolerance</c> window
+        /// against the current clock. May indicate clock drift on the integrator's
+        /// server or a replay attack.
+        /// </summary>
+        TimestampOutOfTolerance,
+    }
+}

--- a/src/MercadoPago/Webhook/WebhookSignatureValidator.cs
+++ b/src/MercadoPago/Webhook/WebhookSignatureValidator.cs
@@ -1,0 +1,277 @@
+﻿namespace MercadoPago.Webhook
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Security.Cryptography;
+    using System.Text;
+    using System.Text.RegularExpressions;
+    using MercadoPago.Error;
+
+    /// <summary>
+    /// Verifies the authenticity of an incoming MercadoPago webhook notification by
+    /// recomputing the HMAC-SHA256 signature locally and comparing it against the value
+    /// in the <c>x-signature</c> header.
+    /// </summary>
+    /// <remarks>
+    /// This is a stateless, CPU-only utility. It performs no outbound HTTP calls and
+    /// does not depend on <c>MercadoPagoConfig</c>; the integrator passes the secret
+    /// signature explicitly on every call. The comparison is performed in constant time
+    /// (via <see cref="CryptographicOperations.FixedTimeEquals"/>) to mitigate timing attacks.
+    /// <para>
+    /// On failure, the validator throws <see cref="InvalidWebhookSignatureException"/>
+    /// with a specific <see cref="SignatureFailureReason"/>. The integrator should
+    /// respond with HTTP 401 to MercadoPago in all failure cases, log the
+    /// <see cref="InvalidWebhookSignatureException.RequestId"/> for correlation,
+    /// and not expose the failure reason in the HTTP response body.
+    /// </para>
+    /// <para>
+    /// QR Code notifications are <b>not signed</b> by MercadoPago — do not call this
+    /// validator for those events; they will always fail signature verification.
+    /// </para>
+    /// </remarks>
+    public static class WebhookSignatureValidator
+    {
+        private static readonly IReadOnlyList<string> DefaultSupportedVersions = new[] { "v1" };
+        private static readonly Regex VersionKeyRegex = new Regex(@"^v\d+$", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Validates the signature of a MercadoPago webhook notification.
+        /// </summary>
+        /// <param name="xSignature">
+        /// The raw value of the <c>x-signature</c> request header. Expected to follow
+        /// the format <c>ts=&lt;ms&gt;,v1=&lt;hex&gt;</c>.
+        /// </param>
+        /// <param name="xRequestId">
+        /// The value of the <c>x-request-id</c> request header. Optional in the manifest:
+        /// if <c>null</c>, empty, or whitespace, the <c>request-id:</c> pair is omitted
+        /// before computing the HMAC.
+        /// </param>
+        /// <param name="dataId">
+        /// The value of the <c>data.id</c> query string parameter. Optional in the manifest:
+        /// if <c>null</c>, empty, or whitespace, the <c>id:</c> pair is omitted. When present,
+        /// the value is lowercased before being included in the manifest.
+        /// </param>
+        /// <param name="secret">
+        /// The secret signature configured for the application in Tus Integraciones.
+        /// Used as the HMAC key.
+        /// </param>
+        /// <param name="tolerance">
+        /// Optional maximum allowed drift between the timestamp in the header and
+        /// <see cref="DateTimeOffset.UtcNow"/>. When <c>null</c>, no timestamp check
+        /// is performed. Setting this to a small window (e.g. five minutes) mitigates
+        /// replay attacks.
+        /// </param>
+        /// <param name="supportedVersions">
+        /// Optional ordered list of signature versions the SDK will accept. Defaults
+        /// to <c>{"v1"}</c>. The validator iterates through this list and uses the
+        /// first version found in the header, allowing forward compatibility with future
+        /// signature schemes (e.g. <c>v2</c>) without breaking older integrations.
+        /// </param>
+        /// <exception cref="InvalidWebhookSignatureException">
+        /// Thrown when the signature is missing, malformed, or does not match the
+        /// expected HMAC. Inspect <see cref="InvalidWebhookSignatureException.Reason"/>
+        /// for the specific failure mode.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="secret"/> is <c>null</c>.
+        /// </exception>
+        public static void Validate(
+            string xSignature,
+            string xRequestId,
+            string dataId,
+            string secret,
+            TimeSpan? tolerance = null,
+            IReadOnlyCollection<string> supportedVersions = null)
+        {
+            if (secret == null)
+            {
+                throw new ArgumentNullException(nameof(secret));
+            }
+
+            var normalizedSignature = Normalize(xSignature);
+            var normalizedRequestId = Normalize(xRequestId);
+            var normalizedDataId = Normalize(dataId);
+            var versions = supportedVersions ?? DefaultSupportedVersions;
+
+            if (normalizedSignature == null)
+            {
+                throw new InvalidWebhookSignatureException(
+                    SignatureFailureReason.MissingSignatureHeader,
+                    normalizedRequestId);
+            }
+
+            var parsed = ParseSignatureHeader(normalizedSignature);
+
+            if (parsed.Timestamp == null && parsed.Hashes.Count == 0)
+            {
+                throw new InvalidWebhookSignatureException(
+                    SignatureFailureReason.MalformedSignatureHeader,
+                    normalizedRequestId);
+            }
+
+            if (parsed.Timestamp == null)
+            {
+                throw new InvalidWebhookSignatureException(
+                    SignatureFailureReason.MissingTimestamp,
+                    normalizedRequestId);
+            }
+
+            if (!long.TryParse(parsed.Timestamp, NumberStyles.None, CultureInfo.InvariantCulture, out var timestampMs))
+            {
+                throw new InvalidWebhookSignatureException(
+                    SignatureFailureReason.MalformedSignatureHeader,
+                    normalizedRequestId,
+                    parsed.Timestamp);
+            }
+
+            string receivedHash = null;
+            foreach (var version in versions)
+            {
+                if (parsed.Hashes.TryGetValue(version, out var hash))
+                {
+                    receivedHash = hash;
+                    break;
+                }
+            }
+
+            if (receivedHash == null)
+            {
+                throw new InvalidWebhookSignatureException(
+                    SignatureFailureReason.MissingHash,
+                    normalizedRequestId,
+                    parsed.Timestamp);
+            }
+
+            var manifest = BuildManifest(normalizedDataId, normalizedRequestId, parsed.Timestamp);
+            var computedHash = ComputeHmacHex(secret, manifest);
+
+            if (!ConstantTimeEquals(computedHash, receivedHash))
+            {
+                throw new InvalidWebhookSignatureException(
+                    SignatureFailureReason.SignatureMismatch,
+                    normalizedRequestId,
+                    parsed.Timestamp);
+            }
+
+            if (tolerance.HasValue)
+            {
+                var driftMs = Math.Abs(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - timestampMs);
+                if (driftMs > (long)tolerance.Value.TotalMilliseconds)
+                {
+                    throw new InvalidWebhookSignatureException(
+                        SignatureFailureReason.TimestampOutOfTolerance,
+                        normalizedRequestId,
+                        parsed.Timestamp);
+                }
+            }
+        }
+
+        private static string Normalize(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+
+            return value.Trim();
+        }
+
+        private static ParsedSignature ParseSignatureHeader(string header)
+        {
+            var hashes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            string ts = null;
+
+            foreach (var part in header.Split(','))
+            {
+                var eqIndex = part.IndexOf('=');
+                if (eqIndex <= 0 || eqIndex == part.Length - 1)
+                {
+                    continue;
+                }
+
+                var key = part.Substring(0, eqIndex).Trim().ToLowerInvariant();
+                var value = part.Substring(eqIndex + 1).Trim();
+
+                if (key.Length == 0 || value.Length == 0)
+                {
+                    continue;
+                }
+
+                if (key == "ts")
+                {
+                    ts = value;
+                }
+                else if (VersionKeyRegex.IsMatch(key))
+                {
+                    hashes[key] = value;
+                }
+            }
+
+            return new ParsedSignature(ts, hashes);
+        }
+
+        private static string BuildManifest(string dataId, string requestId, string timestamp)
+        {
+            var parts = new List<string>(3);
+            if (dataId != null)
+            {
+                parts.Add($"id:{dataId.ToLowerInvariant()}");
+            }
+
+            if (requestId != null)
+            {
+                parts.Add($"request-id:{requestId}");
+            }
+
+            parts.Add($"ts:{timestamp}");
+            return string.Join(";", parts) + ";";
+        }
+
+        private static string ComputeHmacHex(string secret, string message)
+        {
+            using (var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret)))
+            {
+                var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(message));
+                return ToHexLower(hash);
+            }
+        }
+
+        private static string ToHexLower(byte[] bytes)
+        {
+            var sb = new StringBuilder(bytes.Length * 2);
+            foreach (var b in bytes)
+            {
+                sb.Append(b.ToString("x2", CultureInfo.InvariantCulture));
+            }
+
+            return sb.ToString();
+        }
+
+        private static bool ConstantTimeEquals(string a, string b)
+        {
+            if (a == null || b == null || a.Length != b.Length)
+            {
+                return false;
+            }
+
+            var bytesA = Encoding.UTF8.GetBytes(a);
+            var bytesB = Encoding.UTF8.GetBytes(b);
+            return CryptographicOperations.FixedTimeEquals(bytesA, bytesB);
+        }
+
+        private readonly struct ParsedSignature
+        {
+            public ParsedSignature(string timestamp, IReadOnlyDictionary<string, string> hashes)
+            {
+                Timestamp = timestamp;
+                Hashes = hashes;
+            }
+
+            public string Timestamp { get; }
+
+            public IReadOnlyDictionary<string, string> Hashes { get; }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds a stateless utility to verify the authenticity of incoming MercadoPago webhook notifications by recomputing the HMAC-SHA256 signature and comparing it against the `x-signature` header in constant time (timing-attack safe).

## Changes
- `MercadoPago/Webhook/WebhookSignatureValidator.cs`: HMAC-SHA256 validator with explicit secret per call, no MercadoPagoConfig dependency
- `MercadoPago/Error/InvalidWebhookSignatureException.cs`: typed exception thrown on validation failures
- `MercadoPago/Error/SignatureFailureReason.cs`: enum of specific failure reasons (missing header, malformed signature, hash mismatch, etc.)
- `MercadoPago.Tests/Webhook/WebhookSignatureValidatorTest.cs`: unit tests covering success, malformed inputs, timestamp window, hash mismatch

## Test plan
- [ ] CI green