### PR TITLE
feat(order): add missing AP fields to order request models (IXE-679)

### DIFF
--- a/src/MercadoPago/Client/Order/OrderCreateRequest.cs
+++ b/src/MercadoPago/Client/Order/OrderCreateRequest.cs
@@ -109,5 +109,11 @@ namespace MercadoPago.Client.Order
         /// Free-form dictionary for any additional metadata to attach to the order.
         /// </summary>
         public IDictionary<string, object> AdditionalInfo { get; set; }
+
+        /// <summary>
+        /// Integration metadata identifying the integrator, platform, corporation, and sponsor.
+        /// </summary>
+        /// <seealso cref="OrderIntegrationDataRequest"/>
+        public OrderIntegrationDataRequest IntegrationData { get; set; }
     }
 }

--- a/src/MercadoPago/Client/Order/OrderIntegrationDataRequest.cs
+++ b/src/MercadoPago/Client/Order/OrderIntegrationDataRequest.cs
@@ -1,0 +1,25 @@
+// API version: d0494f1c-8d81-4c76-ae1d-0c65bb8ef6de
+
+namespace MercadoPago.Client.Order
+{
+    /// <summary>
+    /// Integration metadata for an order. Identifies the integrator, platform,
+    /// and corporation associated with the integration, as well as any sponsoring
+    /// marketplace owner.
+    /// </summary>
+    public class OrderIntegrationDataRequest
+    {
+        /// <summary>Identifier of the certified integrator. Type: string.</summary>
+        public string IntegratorId { get; set; }
+
+        /// <summary>Platform identifier assigned by MercadoPago. Type: string.</summary>
+        public string PlatformId { get; set; }
+
+        /// <summary>Corporation identifier for multi-account setups. Type: string.</summary>
+        public string CorporationId { get; set; }
+
+        /// <summary>Sponsor (marketplace owner) information.</summary>
+        /// <seealso cref="OrderSponsorRequest"/>
+        public OrderSponsorRequest Sponsor { get; set; }
+    }
+}

--- a/src/MercadoPago/Client/Order/OrderPaymentRequest.cs
+++ b/src/MercadoPago/Client/Order/OrderPaymentRequest.cs
@@ -24,6 +24,13 @@ namespace MercadoPago.Client.Order
         public string ExpirationTime { get; set; }
 
         /// <summary>
+        /// Absolute date and time (ISO 8601) after which this payment can no longer be collected.
+        /// Distinct from <see cref="ExpirationTime"/> which is a relative duration or TTL.
+        /// Type: string (ISO 8601, e.g. "2026-06-01T00:00:00.000-04:00").
+        /// </summary>
+        public string DateOfExpiration { get; set; }
+
+        /// <summary>
         /// Payment method details including method type, card token, and installments.
         /// </summary>
         /// <seealso cref="OrderPaymentMethodRequest"/>

--- a/src/MercadoPago/Client/Order/OrderSponsorRequest.cs
+++ b/src/MercadoPago/Client/Order/OrderSponsorRequest.cs
@@ -1,0 +1,14 @@
+// API version: d0494f1c-8d81-4c76-ae1d-0c65bb8ef6de
+
+namespace MercadoPago.Client.Order
+{
+    /// <summary>
+    /// Sponsoring marketplace owner associated with an order's integration metadata.
+    /// </summary>
+    /// <seealso cref="OrderIntegrationDataRequest"/>
+    public class OrderSponsorRequest
+    {
+        /// <summary>MercadoPago user ID of the sponsoring marketplace owner. Type: string.</summary>
+        public string Id { get; set; }
+    }
+}

--- a/src/MercadoPago/Client/Order/OrderStoredCredentialRequest.cs
+++ b/src/MercadoPago/Client/Order/OrderStoredCredentialRequest.cs
@@ -29,6 +29,13 @@ namespace MercadoPago.Client.Order
         /// Indicates whether this is the first payment in a series of recurring charges.
         /// </summary>
         public bool? FirstPayment { get; set; }
+
+        /// <summary>
+        /// Reference to the previous transaction in a recurring series. Required from the second
+        /// charge onwards to link this payment to the original card-network authorization.
+        /// Type: string (transaction ID).
+        /// </summary>
+        public string PrevTransactionRef { get; set; }
     }
 
 }


### PR DESCRIPTION
## Summary

- **OrderStoredCredentialRequest** → added `PrevTransactionRef string` — links each recurring charge to the original card-network authorization; required from the second charge onwards in the AP flow.
- **OrderPaymentRequest** → added `DateOfExpiration string` (ISO 8601) — absolute payment expiry date, distinct from the relative `ExpirationTime` TTL.
- **OrderIntegrationDataRequest** (new class) → `IntegratorId`, `PlatformId`, `CorporationId` (string) + `Sponsor: OrderSponsorRequest` — integration metadata for marketplace and platform identification.
- **OrderSponsorRequest** (new class) → `Id string` — MercadoPago user ID of the sponsoring marketplace owner.
- **OrderCreateRequest** → added `IntegrationData: OrderIntegrationDataRequest`.

All fields are nullable by default. `NullValueHandling.Ignore` + `SnakeCaseNamingStrategy` handle serialization automatically — no `[JsonProperty]` attributes needed. Zero break changes.

## Context

Part of IXE-679: fields required for the Automatic Payments (recurring without CVV) flow in the Orders API were missing from the public SDKs. Companion PRs exist for Java, Go, Node.js, PHP, Python and Ruby.

## Test plan

- [x] `dotnet build src/MercadoPago/MercadoPago.csproj` — 0 errors
- [x] `dotnet test --filter FullyQualifiedName~Order --framework net8.0` — Failed: 0, Passed: 4, Skipped: 23
- [ ] Integration tests (not run per policy)

Generated with [Claude Code](https://claude.com/claude-code)