### PR TITLE
fix(webhook): preserve data.id case in signature manifest

### DIFF
--- a/src/MercadoPago.Tests/Webhook/WebhookSignatureValidatorTest.cs
+++ b/src/MercadoPago.Tests/Webhook/WebhookSignatureValidatorTest.cs
@@ -22,7 +22,7 @@
             var parts = new System.Collections.Generic.List<string>(3);
             if (!string.IsNullOrWhiteSpace(dataId))
             {
-                parts.Add($"id:{dataId.ToLowerInvariant()}");
+                parts.Add($"id:{dataId}");
             }
 
             if (!string.IsNullOrWhiteSpace(requestId))
@@ -58,12 +58,12 @@
                 BuildHeader(hash, ts), RequestId, DataIdLower, Secret);
         }
 
-        // --- Canonical case 2: dataId in uppercase — SDK must lowercase before HMAC ---
+        // --- Canonical case 2: dataId in uppercase — SDK must preserve casing in HMAC ---
         [Fact]
         public void Validate_DataIdInUppercase_StillValidates()
         {
             var ts = CurrentTs();
-            var hash = ComputeHash(DataIdLower, RequestId, ts, Secret);
+            var hash = ComputeHash(DataIdRaw, RequestId, ts, Secret);
 
             WebhookSignatureValidator.Validate(
                 BuildHeader(hash, ts), RequestId, DataIdRaw, Secret);

--- a/src/MercadoPago/Webhook/WebhookSignatureValidator.cs
+++ b/src/MercadoPago/Webhook/WebhookSignatureValidator.cs
@@ -51,7 +51,7 @@
         /// <param name="dataId">
         /// The value of the <c>data.id</c> query string parameter. Optional in the manifest:
         /// if <c>null</c>, empty, or whitespace, the <c>id:</c> pair is omitted. When present,
-        /// the value is lowercased before being included in the manifest.
+        /// the value is included in the manifest exactly as received.
         /// </param>
         /// <param name="secret">
         /// The secret signature configured for the application in Tus Integraciones.
@@ -217,7 +217,7 @@
             var parts = new List<string>(3);
             if (dataId != null)
             {
-                parts.Add($"id:{dataId.ToLowerInvariant()}");
+                parts.Add($"id:{dataId}");
             }
 
             if (requestId != null)


### PR DESCRIPTION
## Problem

`WebhookSignatureValidator.Validate` was calling `.ToLowerInvariant()` on `dataId` before building the HMAC manifest. MercadoPago signs webhook notifications using the original casing of `data.id`, so any notification with uppercase or mixed-case identifiers would fail validation with `SignatureMismatch`.

## Fix

Remove the `.ToLowerInvariant()` call in `BuildManifest` so the value is included exactly as received. The XML doc comment is updated accordingly.

## Testing

Verified manually with `data.id` values in uppercase (`ORDER123`), lowercase (`order123`), and mixed case (`oRdEr`) — all pass when the signature was generated with the same casing.