### PR TITLE
Add missing industry fields across Payment, Preference, and Order models

### DIFF
--- a/src/MercadoPago.Tests/Client/Order/OrderClientMockedTest.cs
+++ b/src/MercadoPago.Tests/Client/Order/OrderClientMockedTest.cs
@@ -128,10 +128,10 @@ namespace MercadoPago.Tests.Client.Order
                         EventDate = "2027-01-15T00:00:00.000-03:00"
                     }
                 },
-                AdditionalInfo = new Dictionary<string, object>
+                AdditionalInfo = new OrderAdditionalInfoRequest
                 {
-                    ["payer.registration_date"] = "2020-01-15T00:00:00.000-03:00",
-                    ["payer.is_prime_user"] = true
+                    RegistrationDate = "2020-01-15T00:00:00.000-03:00",
+                    IsPrimeUser = true
                 }
             };
 
@@ -258,10 +258,10 @@ namespace MercadoPago.Tests.Client.Order
                     }
                 },
                 Payer = new OrderPayerRequest { Email = "test_user@example.com" },
-                AdditionalInfo = new Dictionary<string, object>
+                AdditionalInfo = new OrderAdditionalInfoRequest
                 {
-                    ["payer"] = new Dictionary<string, object> { ["authentication_type"] = "senha" },
-                    ["shipment"] = new Dictionary<string, object> { ["express"] = true }
+                    AuthenticationType = "senha",
+                    Express = true
                 }
             };
 

--- a/src/MercadoPago/Client/Order/OrderAdditionalInfoRequest.cs
+++ b/src/MercadoPago/Client/Order/OrderAdditionalInfoRequest.cs
@@ -1,0 +1,64 @@
+// API version: d0494f1c-8d81-4c76-ae1d-0c65bb8ef6de
+
+namespace MercadoPago.Client.Order
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Typed additional information attached to an <see cref="OrderCreateRequest"/> to improve
+    /// fraud analysis and risk scoring. Fields use dotted-notation JSON keys as required by the
+    /// Orders API (<c>POST /v1/orders</c>).
+    /// </summary>
+    /// <seealso cref="OrderCreateRequest"/>
+    public class OrderAdditionalInfoRequest
+    {
+        /// <summary>
+        /// Authentication method used by the payer on the merchant's site
+        /// (e.g., <c>"Gmail"</c>, <c>"Facebook"</c>, <c>"Native"</c>).
+        /// </summary>
+        [JsonProperty("payer.authentication_type")]
+        public string AuthenticationType { get; set; }
+
+        /// <summary>
+        /// Date when the payer registered on the merchant's site, in ISO 8601 format.
+        /// Used for fraud risk assessment based on account age.
+        /// </summary>
+        [JsonProperty("payer.registration_date")]
+        public string RegistrationDate { get; set; }
+
+        /// <summary>
+        /// <c>true</c> if the payer is a premium or prime user on the merchant's platform;
+        /// otherwise, <c>false</c>.
+        /// </summary>
+        [JsonProperty("payer.is_prime_user")]
+        public bool? IsPrimeUser { get; set; }
+
+        /// <summary>
+        /// <c>true</c> if this is the payer's first online purchase on the merchant's platform;
+        /// otherwise, <c>false</c>.
+        /// </summary>
+        [JsonProperty("payer.is_first_purchase_online")]
+        public bool? IsFirstPurchaseOnline { get; set; }
+
+        /// <summary>
+        /// Date and time of the payer's most recent purchase on the merchant's platform,
+        /// in ISO 8601 format.
+        /// </summary>
+        [JsonProperty("payer.last_purchase")]
+        public string LastPurchase { get; set; }
+
+        /// <summary>
+        /// <c>true</c> if the shipment should be delivered via an express (same-day or next-day) method;
+        /// otherwise, <c>false</c>.
+        /// </summary>
+        [JsonProperty("shipment.express")]
+        public bool? Express { get; set; }
+
+        /// <summary>
+        /// <c>true</c> if the buyer will collect the order at a physical location (click &amp; collect);
+        /// otherwise, <c>false</c>.
+        /// </summary>
+        [JsonProperty("shipment.local_pickup")]
+        public bool? LocalPickup { get; set; }
+    }
+}

--- a/src/MercadoPago/Client/Order/OrderCreateRequest.cs
+++ b/src/MercadoPago/Client/Order/OrderCreateRequest.cs
@@ -106,9 +106,12 @@ namespace MercadoPago.Client.Order
         public OrderShipmentRequest Shipment { get; set; }
 
         /// <summary>
-        /// Free-form dictionary for any additional metadata to attach to the order.
+        /// Typed additional metadata to attach to the order for fraud analysis and risk scoring.
+        /// Contains payer behaviour signals and shipment preferences using the dotted-key convention
+        /// required by the Orders API.
         /// </summary>
-        public IDictionary<string, object> AdditionalInfo { get; set; }
+        /// <seealso cref="OrderAdditionalInfoRequest"/>
+        public OrderAdditionalInfoRequest AdditionalInfo { get; set; }
 
         /// <summary>
         /// Integration metadata identifying the integrator, platform, corporation, and sponsor.

--- a/src/MercadoPago/Client/Payment/PaymentAdditionalInfoPayerRequest.cs
+++ b/src/MercadoPago/Client/Payment/PaymentAdditionalInfoPayerRequest.cs
@@ -60,5 +60,11 @@
         /// Date and time of the payer's last purchase on the merchant's platform.
         /// </summary>
         public DateTime? LastPurchase { get; set; }
+
+        /// <summary>
+        /// Payer's personal identification document data (type and number).
+        /// </summary>
+        /// <seealso cref="IdentificationRequest"/>
+        public IdentificationRequest Identification { get; set; }
     }
 }

--- a/src/MercadoPago/Client/Payment/PaymentItemRequest.cs
+++ b/src/MercadoPago/Client/Payment/PaymentItemRequest.cs
@@ -34,6 +34,11 @@
         public string CategoryId { get; set; }
 
         /// <summary>
+        /// Item classification type (e.g., "travel", "physical_goods").
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
         /// Quantity of this item being purchased.
         /// </summary>
         public int? Quantity { get; set; }

--- a/src/MercadoPago/Client/Preference/PreferenceItemRequest.cs
+++ b/src/MercadoPago/Client/Preference/PreferenceItemRequest.cs
@@ -34,6 +34,12 @@
         public string CategoryId { get; set; }
 
         /// <summary>
+        /// Item type identifier used for industry-specific processing rules
+        /// (e.g., <c>"product"</c>, <c>"service"</c>, <c>"travel"</c>).
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
         /// Number of units of this item. Must be an integer greater than zero.
         /// </summary>
         public int? Quantity { get; set; }

--- a/src/MercadoPago/Resource/Payment/PaymentAdditionalInfoPayer.cs
+++ b/src/MercadoPago/Resource/Payment/PaymentAdditionalInfoPayer.cs
@@ -34,5 +34,33 @@
         /// fraud analysis to assess account age.
         /// </summary>
         public DateTime? RegistrationDate { get; set; }
+
+        /// <summary>
+        /// Authentication method used by the payer on the merchant's site
+        /// (e.g., "Gmail", "Facebook", "Native").
+        /// </summary>
+        public string AuthenticationType { get; set; }
+
+        /// <summary>
+        /// <c>true</c> if the payer is a premium or prime user on the merchant's platform;
+        /// otherwise, <c>false</c>.
+        /// </summary>
+        public bool? IsPrimeUser { get; set; }
+
+        /// <summary>
+        /// <c>true</c> if this is the payer's first online purchase on the merchant's platform;
+        /// otherwise, <c>false</c>.
+        /// </summary>
+        public bool? IsFirstPurchaseOnline { get; set; }
+
+        /// <summary>
+        /// Date and time of the payer's last purchase on the merchant's platform.
+        /// </summary>
+        public DateTime? LastPurchase { get; set; }
+
+        /// <summary>
+        /// Payer's personal identification document data (type and number).
+        /// </summary>
+        public Identification Identification { get; set; }
     }
 }

--- a/src/MercadoPago/Resource/Preference/PreferenceItem.cs
+++ b/src/MercadoPago/Resource/Preference/PreferenceItem.cs
@@ -36,6 +36,12 @@
         public string CategoryId { get; set; }
 
         /// <summary>
+        /// Item type identifier used for industry-specific processing rules
+        /// (e.g., <c>"product"</c>, <c>"service"</c>, <c>"travel"</c>).
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
         /// Number of units of this item being purchased.
         /// </summary>
         public int? Quantity { get; set; }


### PR DESCRIPTION
- PreferenceItemRequest/PreferenceItem: add Type
- PaymentItemRequest: add Type
- PaymentAdditionalInfoPayerRequest: add Identification
- PaymentAdditionalInfoPayer: add AuthenticationType, IsPrimeUser, IsFirstPurchaseOnline, LastPurchase, Identification
- OrderCreateRequest: replace IDictionary AdditionalInfo with typed OrderAdditionalInfoRequest class
- New OrderAdditionalInfoRequest: typed fields for payer behavioral data (authentication_type, registration_date, is_prime_user, is_first_purchase_online, last_purchase) and shipment flags