### PR TITLE
fix: escape dynamic API path parameters

### DIFF
--- a/src/MercadoPago.Tests/Client/MercadoPagoClientTest.cs
+++ b/src/MercadoPago.Tests/Client/MercadoPagoClientTest.cs
@@ -141,6 +141,28 @@
             Assert.Equal("world", dummyResource.Name);
         }
 
+        [Fact]
+        public async Task SendAsync_WithEncodedPathParam_Success()
+        {
+            var httpClientMock = new HttpClientMock();
+            var httpClient = new DefaultHttpClient(httpClientMock.HttpClient);
+            var client = new DummyCustomerClient(httpClient, null);
+            var id = "../../applications/123";
+            var url = $"{MercadoPagoConfig.BaseUrl}/v1/customers/..%2F..%2Fapplications%2F123";
+
+            var httpResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{'name':'world'}"),
+            };
+
+            httpClientMock.MockRequest(url, System.Net.Http.HttpMethod.Get, httpResponse);
+
+            DummyResource dummyResource = await client.GetCustomerAsync(id);
+
+            Assert.NotNull(dummyResource);
+            Assert.Equal("world", dummyResource.Name);
+        }
+
         [Fact(Skip = "Not running in CI.")]
         public void Send_WithoutBody_Success()
         {
@@ -483,6 +505,22 @@
             Assert.Equal(0, resultsSearchPage.Paging.Offset);
             Assert.NotNull(resultsSearchPage.Results);
             Assert.True(resultsSearchPage.Results.Count > 0);
+        }
+    }
+
+    internal class DummyCustomerClient : MercadoPagoClient<DummyResource>
+    {
+        public DummyCustomerClient(IHttpClient httpClient, ISerializer serializer)
+            : base(httpClient, serializer)
+        {
+        }
+
+        public Task<DummyResource> GetCustomerAsync(string id)
+        {
+            return SendAsync(
+                $"/v1/customers/{EncodePathParam(id)}",
+                MercadoPago.Http.HttpMethod.GET,
+                null);
         }
     }
 }

--- a/src/MercadoPago/Client/AuthorizedPayment/AuthorizedPaymentClient.cs
+++ b/src/MercadoPago/Client/AuthorizedPayment/AuthorizedPaymentClient.cs
@@ -72,7 +72,7 @@ namespace MercadoPago.Client.AuthorizedPayment
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return SendAsync($"/authorized_payments/{id}", HttpMethod.GET, null, requestOptions, cancellationToken);
+            return SendAsync($"/authorized_payments/{EncodePathParam(id)}", HttpMethod.GET, null, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace MercadoPago.Client.AuthorizedPayment
             long id,
             RequestOptions requestOptions = null)
         {
-            return Send($"/authorized_payments/{id}", HttpMethod.GET, null, requestOptions);
+            return Send($"/authorized_payments/{EncodePathParam(id)}", HttpMethod.GET, null, requestOptions);
         }
 
         /// <summary>

--- a/src/MercadoPago/Client/Chargeback/ChargebackClient.cs
+++ b/src/MercadoPago/Client/Chargeback/ChargebackClient.cs
@@ -75,7 +75,7 @@ namespace MercadoPago.Client.Chargeback
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return SendAsync($"/v1/chargebacks/{id}", HttpMethod.GET, null, requestOptions, cancellationToken);
+            return SendAsync($"/v1/chargebacks/{EncodePathParam(id)}", HttpMethod.GET, null, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace MercadoPago.Client.Chargeback
             long id,
             RequestOptions requestOptions = null)
         {
-            return Send($"/v1/chargebacks/{id}", HttpMethod.GET, null, requestOptions);
+            return Send($"/v1/chargebacks/{EncodePathParam(id)}", HttpMethod.GET, null, requestOptions);
         }
 
         /// <summary>

--- a/src/MercadoPago/Client/Customer/CustomerCardClient.cs
+++ b/src/MercadoPago/Client/Customer/CustomerCardClient.cs
@@ -79,7 +79,7 @@
             CancellationToken cancellationToken = default)
         {
             return SendAsync(
-                $"/v1/customers/{customerId}/cards/{cardId}",
+                $"/v1/customers/{EncodePathParam(customerId)}/cards/{EncodePathParam(cardId)}",
                 HttpMethod.GET,
                 requestOptions,
                 null,
@@ -105,7 +105,7 @@
             RequestOptions requestOptions = null)
         {
             return Send(
-                $"/v1/customers/{customerId}/cards/{cardId}",
+                $"/v1/customers/{EncodePathParam(customerId)}/cards/{EncodePathParam(cardId)}",
                 HttpMethod.GET,
                 null,
                 requestOptions);
@@ -132,7 +132,7 @@
             CancellationToken cancellationToken = default)
         {
             return SendAsync(
-                $"/v1/customers/{customerId}/cards",
+                $"/v1/customers/{EncodePathParam(customerId)}/cards",
                 HttpMethod.POST,
                 request,
                 requestOptions,
@@ -158,7 +158,7 @@
             RequestOptions requestOptions = null)
         {
             return Send(
-                $"/v1/customers/{customerId}/cards",
+                $"/v1/customers/{EncodePathParam(customerId)}/cards",
                 HttpMethod.POST,
                 request,
                 requestOptions);
@@ -185,7 +185,7 @@
             CancellationToken cancellationToken = default)
         {
             return SendAsync(
-                $"/v1/customers/{customerId}/cards/{cardId}",
+                $"/v1/customers/{EncodePathParam(customerId)}/cards/{EncodePathParam(cardId)}",
                 HttpMethod.DELETE,
                 null,
                 requestOptions,
@@ -211,7 +211,7 @@
             RequestOptions requestOptions = null)
         {
             return Send(
-                $"/v1/customers/{customerId}/cards/{cardId}",
+                $"/v1/customers/{EncodePathParam(customerId)}/cards/{EncodePathParam(cardId)}",
                 HttpMethod.DELETE,
                 null,
                 requestOptions);
@@ -236,7 +236,7 @@
             CancellationToken cancellationToken = default)
         {
             return ListAsync(
-                $"/v1/customers/{customerId}/cards",
+                $"/v1/customers/{EncodePathParam(customerId)}/cards",
                 HttpMethod.GET,
                 null,
                 requestOptions,
@@ -260,7 +260,7 @@
             RequestOptions requestOptions = null)
         {
             return List(
-                $"/v1/customers/{customerId}/cards",
+                $"/v1/customers/{EncodePathParam(customerId)}/cards",
                 HttpMethod.GET,
                 null,
                 requestOptions);

--- a/src/MercadoPago/Client/Customer/CustomerClient.cs
+++ b/src/MercadoPago/Client/Customer/CustomerClient.cs
@@ -79,7 +79,7 @@
             CancellationToken cancellationToken = default)
         {
             return SendAsync(
-                $"/v1/customers/{id}",
+                $"/v1/customers/{EncodePathParam(id)}",
                 HttpMethod.GET,
                 null,
                 requestOptions,
@@ -103,7 +103,7 @@
             RequestOptions requestOptions = null)
         {
             return Send(
-                $"/v1/customers/{id}",
+                $"/v1/customers/{EncodePathParam(id)}",
                 HttpMethod.GET,
                 null,
                 requestOptions);
@@ -180,7 +180,7 @@
             CancellationToken cancellationToken = default)
         {
             return SendAsync(
-                $"/v1/customers/{id}",
+                $"/v1/customers/{EncodePathParam(id)}",
                 HttpMethod.PUT,
                 request,
                 requestOptions,
@@ -207,7 +207,7 @@
             RequestOptions requestOptions = null)
         {
             return Send(
-                $"/v1/customers/{id}",
+                $"/v1/customers/{EncodePathParam(id)}",
                 HttpMethod.PUT,
                 request,
                 requestOptions);
@@ -228,7 +228,7 @@
             CancellationToken cancellationToken = default)
         {
             return SendAsync(
-                $"/v1/customers/{id}",
+                $"/v1/customers/{EncodePathParam(id)}",
                 HttpMethod.DELETE,
                 null,
                 requestOptions,
@@ -248,7 +248,7 @@
             RequestOptions requestOptions = null)
         {
             return Send(
-                $"/v1/customers/{id}",
+                $"/v1/customers/{EncodePathParam(id)}",
                 HttpMethod.DELETE,
                 null,
                 requestOptions);

--- a/src/MercadoPago/Client/MercadoPagoClient.cs
+++ b/src/MercadoPago/Client/MercadoPagoClient.cs
@@ -58,6 +58,14 @@
         public ISerializer Serializer { get; }
 
         /// <summary>
+        /// Encodes a dynamic URL path segment before it is interpolated into an endpoint path.
+        /// </summary>
+        protected static string EncodePathParam(object value)
+        {
+            return Uri.EscapeDataString(value?.ToString() ?? string.Empty);
+        }
+
+        /// <summary>
         /// The default headers sent with every API request, including <c>Accept</c>,
         /// <c>User-Agent</c>, product ID, and tracking ID.
         /// </summary>

--- a/src/MercadoPago/Client/Order/OrderClient.cs
+++ b/src/MercadoPago/Client/Order/OrderClient.cs
@@ -128,7 +128,7 @@
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return SendAsync($"/v1/orders/{id}", HttpMethod.GET, null, requestOptions, cancellationToken);
+            return SendAsync($"/v1/orders/{EncodePathParam(id)}", HttpMethod.GET, null, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -147,7 +147,7 @@
             string id,
             RequestOptions requestOptions = null)
         {
-            return Send($"/v1/orders/{id}", HttpMethod.GET, null, requestOptions);
+            return Send($"/v1/orders/{EncodePathParam(id)}", HttpMethod.GET, null, requestOptions);
         }
 
         /// <summary>
@@ -169,7 +169,7 @@
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return SendAsync($"/v1/orders/{id}/process", HttpMethod.POST, null, requestOptions, cancellationToken);
+            return SendAsync($"/v1/orders/{EncodePathParam(id)}/process", HttpMethod.POST, null, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -189,7 +189,7 @@
             string id,
             RequestOptions requestOptions = null)
         {
-            return Send($"/v1/orders/{id}/process", HttpMethod.POST, null, requestOptions);
+            return Send($"/v1/orders/{EncodePathParam(id)}/process", HttpMethod.POST, null, requestOptions);
         }
 
         /// <summary>
@@ -211,7 +211,7 @@
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return SendAsync($"/v1/orders/{id}/capture", HttpMethod.POST, null, requestOptions, cancellationToken);
+            return SendAsync($"/v1/orders/{EncodePathParam(id)}/capture", HttpMethod.POST, null, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -231,7 +231,7 @@
             string id,
             RequestOptions requestOptions = null)
         {
-            return Send($"/v1/orders/{id}/capture", HttpMethod.POST, null, requestOptions);
+            return Send($"/v1/orders/{EncodePathParam(id)}/capture", HttpMethod.POST, null, requestOptions);
         }
 
         /// <summary>
@@ -253,7 +253,7 @@
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return SendAsync($"/v1/orders/{id}/cancel", HttpMethod.POST, null, requestOptions, cancellationToken);
+            return SendAsync($"/v1/orders/{EncodePathParam(id)}/cancel", HttpMethod.POST, null, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -273,7 +273,7 @@
             string id,
             RequestOptions requestOptions = null)
         {
-            return Send($"/v1/orders/{id}/cancel", HttpMethod.POST, null, requestOptions);
+            return Send($"/v1/orders/{EncodePathParam(id)}/cancel", HttpMethod.POST, null, requestOptions);
         }
 
         /// <summary>

--- a/src/MercadoPago/Client/Order/OrderRefundClient.cs
+++ b/src/MercadoPago/Client/Order/OrderRefundClient.cs
@@ -10,7 +10,7 @@
     /// <summary>
     /// Client responsible for refunding payment orders via the MercadoPago Orders API.
     /// Supports full-order refunds and partial (per-transaction) refunds through
-    /// <c>POST /v1/orders/{id}/refund</c>.
+    /// <c>POST /v1/orders/{EncodePathParam(id)}/refund</c>.
     /// </summary>
     /// <seealso cref="OrderClient"/>
     /// <seealso cref="OrderRefundPaymentRequest"/>
@@ -80,7 +80,7 @@
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return SendAsync($"/v1/orders/{id}/refund", HttpMethod.POST, request, requestOptions, cancellationToken);
+            return SendAsync($"/v1/orders/{EncodePathParam(id)}/refund", HttpMethod.POST, request, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -102,7 +102,7 @@
             OrderRefundPaymentRequest request = null,
             RequestOptions requestOptions = null)
         {
-            return Send($"/v1/orders/{id}/refund", HttpMethod.POST, request, requestOptions);
+            return Send($"/v1/orders/{EncodePathParam(id)}/refund", HttpMethod.POST, request, requestOptions);
         }
 
     }

--- a/src/MercadoPago/Client/Order/OrderTransactionClient.cs
+++ b/src/MercadoPago/Client/Order/OrderTransactionClient.cs
@@ -10,7 +10,7 @@
     /// <summary>
     /// Client responsible for managing individual transactions within a payment order.
     /// Supports creating, updating, and deleting transactions via the MercadoPago Orders API
-    /// (<c>/v1/orders/{id}/transactions</c>). Update operations are delegated to
+    /// (<c>/v1/orders/{EncodePathParam(id)}/transactions</c>). Update operations are delegated to
     /// <see cref="OrderTransactionUpdateClient"/> internally.
     /// </summary>
     /// <seealso cref="OrderClient"/>
@@ -84,7 +84,7 @@
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return SendAsync($"/v1/orders/{id}/transactions", HttpMethod.POST, request, requestOptions, cancellationToken);
+            return SendAsync($"/v1/orders/{EncodePathParam(id)}/transactions", HttpMethod.POST, request, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -105,7 +105,7 @@
             OrderTransactionRequest request,
             RequestOptions requestOptions = null)
         {
-            return Send($"/v1/orders/{id}/transactions", HttpMethod.POST, request, requestOptions);
+            return Send($"/v1/orders/{EncodePathParam(id)}/transactions", HttpMethod.POST, request, requestOptions);
         }
 
         /// <summary>
@@ -176,7 +176,7 @@
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return SendAsync($"/v1/orders/{oderId}/transactions/{transactionId}", HttpMethod.DELETE, null, requestOptions, cancellationToken);
+            return SendAsync($"/v1/orders/{EncodePathParam(oderId)}/transactions/{EncodePathParam(transactionId)}", HttpMethod.DELETE, null, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -197,7 +197,7 @@
             string transactionId,
             RequestOptions requestOptions = null)
         {
-            return Send($"/v1/orders/{oderId}/transactions/{transactionId}", HttpMethod.DELETE, null, requestOptions);
+            return Send($"/v1/orders/{EncodePathParam(oderId)}/transactions/{EncodePathParam(transactionId)}", HttpMethod.DELETE, null, requestOptions);
         }
 
     }

--- a/src/MercadoPago/Client/Order/OrderTransactionUpdateClient.cs
+++ b/src/MercadoPago/Client/Order/OrderTransactionUpdateClient.cs
@@ -9,7 +9,7 @@
 
     /// <summary>
     /// Internal client that handles the HTTP PUT operation for updating a transaction's
-    /// payment details via <c>PUT /v1/orders/{orderId}/transactions/{transactionId}</c>.
+    /// payment details via <c>PUT /v1/orders/{EncodePathParam(orderId)}/transactions/{EncodePathParam(transactionId)}</c>.
     /// This client exists because the update response type (<see cref="OrderUpdateTransaction"/>)
     /// differs from the create/delete response type (<see cref="OrderTransaction"/>),
     /// requiring a separate generic base class binding.
@@ -84,7 +84,7 @@
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return SendAsync($"/v1/orders/{orderId}/transactions/{transactionId}", HttpMethod.PUT, request, requestOptions, cancellationToken);
+            return SendAsync($"/v1/orders/{EncodePathParam(orderId)}/transactions/{EncodePathParam(transactionId)}", HttpMethod.PUT, request, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -107,7 +107,7 @@
             OrderPaymentRequest request,
             RequestOptions requestOptions = null)
         {
-            return Send($"/v1/orders/{orderId}/transactions/{transactionId}", HttpMethod.PUT, request, requestOptions);
+            return Send($"/v1/orders/{EncodePathParam(orderId)}/transactions/{EncodePathParam(transactionId)}", HttpMethod.PUT, request, requestOptions);
         }
 
     }

--- a/src/MercadoPago/Client/Point/PointClient.cs
+++ b/src/MercadoPago/Client/Point/PointClient.cs
@@ -79,7 +79,7 @@ namespace MercadoPago.Client.Point
             CancellationToken cancellationToken = default)
         {
             return SendAsync(
-                $"/point/integration-api/devices/{deviceId}/payment-intents",
+                $"/point/integration-api/devices/{EncodePathParam(deviceId)}/payment-intents",
                 HttpMethod.POST,
                 request,
                 requestOptions,
@@ -101,7 +101,7 @@ namespace MercadoPago.Client.Point
             RequestOptions requestOptions = null)
         {
             return Send(
-                $"/point/integration-api/devices/{deviceId}/payment-intents",
+                $"/point/integration-api/devices/{EncodePathParam(deviceId)}/payment-intents",
                 HttpMethod.POST,
                 request,
                 requestOptions);
@@ -122,7 +122,7 @@ namespace MercadoPago.Client.Point
             CancellationToken cancellationToken = default)
         {
             return SendAsync(
-                $"/point/integration-api/payment-intents/{paymentIntentId}",
+                $"/point/integration-api/payment-intents/{EncodePathParam(paymentIntentId)}",
                 HttpMethod.GET,
                 null,
                 requestOptions,
@@ -142,7 +142,7 @@ namespace MercadoPago.Client.Point
             RequestOptions requestOptions = null)
         {
             return Send(
-                $"/point/integration-api/payment-intents/{paymentIntentId}",
+                $"/point/integration-api/payment-intents/{EncodePathParam(paymentIntentId)}",
                 HttpMethod.GET,
                 null,
                 requestOptions);
@@ -165,7 +165,7 @@ namespace MercadoPago.Client.Point
             CancellationToken cancellationToken = default)
         {
             return SendAsync(
-                $"/point/integration-api/devices/{deviceId}/payment-intents/{paymentIntentId}",
+                $"/point/integration-api/devices/{EncodePathParam(deviceId)}/payment-intents/{EncodePathParam(paymentIntentId)}",
                 HttpMethod.DELETE,
                 null,
                 requestOptions,
@@ -187,7 +187,7 @@ namespace MercadoPago.Client.Point
             RequestOptions requestOptions = null)
         {
             return Send(
-                $"/point/integration-api/devices/{deviceId}/payment-intents/{paymentIntentId}",
+                $"/point/integration-api/devices/{EncodePathParam(deviceId)}/payment-intents/{EncodePathParam(paymentIntentId)}",
                 HttpMethod.DELETE,
                 null,
                 requestOptions);

--- a/src/MercadoPago/Client/PreApprovalPlan/PreApprovalPlanClient.cs
+++ b/src/MercadoPago/Client/PreApprovalPlan/PreApprovalPlanClient.cs
@@ -76,7 +76,7 @@ namespace MercadoPago.Client.PreApprovalPlan
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return SendAsync($"/preapproval_plan/{id}", HttpMethod.GET, null, requestOptions, cancellationToken);
+            return SendAsync($"/preapproval_plan/{EncodePathParam(id)}", HttpMethod.GET, null, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace MercadoPago.Client.PreApprovalPlan
             string id,
             RequestOptions requestOptions = null)
         {
-            return Send($"/preapproval_plan/{id}", HttpMethod.GET, null, requestOptions);
+            return Send($"/preapproval_plan/{EncodePathParam(id)}", HttpMethod.GET, null, requestOptions);
         }
 
         /// <summary>
@@ -142,7 +142,7 @@ namespace MercadoPago.Client.PreApprovalPlan
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return SendAsync($"/preapproval_plan/{id}", HttpMethod.PUT, request, requestOptions, cancellationToken);
+            return SendAsync($"/preapproval_plan/{EncodePathParam(id)}", HttpMethod.PUT, request, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -159,7 +159,7 @@ namespace MercadoPago.Client.PreApprovalPlan
             PreApprovalPlanUpdateRequest request,
             RequestOptions requestOptions = null)
         {
-            return Send($"/preapproval_plan/{id}", HttpMethod.PUT, request, requestOptions);
+            return Send($"/preapproval_plan/{EncodePathParam(id)}", HttpMethod.PUT, request, requestOptions);
         }
 
         /// <summary>

--- a/src/MercadoPago/Client/Preapproval/PreapprovalClient.cs
+++ b/src/MercadoPago/Client/Preapproval/PreapprovalClient.cs
@@ -71,7 +71,7 @@
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return SendAsync($"/preapproval/{id}", HttpMethod.GET, null, requestOptions, cancellationToken);
+            return SendAsync($"/preapproval/{EncodePathParam(id)}", HttpMethod.GET, null, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -86,7 +86,7 @@
             string id,
             RequestOptions requestOptions = null)
         {
-            return Send($"/preapproval/{id}", HttpMethod.GET, null, requestOptions);
+            return Send($"/preapproval/{EncodePathParam(id)}", HttpMethod.GET, null, requestOptions);
         }
 
         /// <summary>
@@ -146,7 +146,7 @@
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return SendAsync($"/preapproval/{id}", HttpMethod.PUT, request, requestOptions, cancellationToken);
+            return SendAsync($"/preapproval/{EncodePathParam(id)}", HttpMethod.PUT, request, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -164,7 +164,7 @@
             PreapprovalUpdateRequest request,
             RequestOptions requestOptions = null)
         {
-            return Send($"/preapproval/{id}", HttpMethod.PUT, request, requestOptions);
+            return Send($"/preapproval/{EncodePathParam(id)}", HttpMethod.PUT, request, requestOptions);
         }
 
         /// <summary>

--- a/src/MercadoPago/Client/Preference/PreferenceClient.cs
+++ b/src/MercadoPago/Client/Preference/PreferenceClient.cs
@@ -76,7 +76,7 @@
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return SendAsync($"/checkout/preferences/{id}", HttpMethod.GET, null, requestOptions, cancellationToken);
+            return SendAsync($"/checkout/preferences/{EncodePathParam(id)}", HttpMethod.GET, null, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -95,7 +95,7 @@
             string id,
             RequestOptions requestOptions = null)
         {
-            return Send($"/checkout/preferences/{id}", HttpMethod.GET, null, requestOptions);
+            return Send($"/checkout/preferences/{EncodePathParam(id)}", HttpMethod.GET, null, requestOptions);
         }
 
         /// <summary>
@@ -159,7 +159,7 @@
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return SendAsync($"/checkout/preferences/{id}", HttpMethod.PUT, request, requestOptions, cancellationToken);
+            return SendAsync($"/checkout/preferences/{EncodePathParam(id)}", HttpMethod.PUT, request, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -181,7 +181,7 @@
             PreferenceRequest request,
             RequestOptions requestOptions = null)
         {
-            return Send($"/checkout/preferences/{id}", HttpMethod.PUT, request, requestOptions);
+            return Send($"/checkout/preferences/{EncodePathParam(id)}", HttpMethod.PUT, request, requestOptions);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds a shared path-parameter encoder in the base MercadoPago client.
- Applies encoding to dynamic string IDs across customer, customer card, chargeback, authorized payment, order, point, preapproval, preapproval plan and preference endpoints.
- Adds a regression test for traversal-style path parameters.

## Validation
- Build reached test execution via `dotnet test src/MercadoPago.Tests/MercadoPago.Tests.csproj --filter SendAsync_WithEncodedPathParam_Success`.
- Test execution could not complete locally because Microsoft.NETCore.App 8.0.0 runtime is not installed; only 10.0.9 is available.