### PR TITLE
fix: make OrderPaymentMethodRequest.Installments nullable

### DIFF
--- a/src/MercadoPago/Client/Order/OrderCreateRequest.cs
+++ b/src/MercadoPago/Client/Order/OrderCreateRequest.cs
@@ -46,8 +46,13 @@ namespace MercadoPago.Client.Order
         public string CaptureMode { get; set; } = "automatic_async";
 
         /// <summary>
-        /// Configures which processing mode to use for the order (e.g., "aggregator" or "gateway").
+        /// Configures the order processing mode.
         /// </summary>
+        /// <remarks>
+        /// Supported values:
+        /// - "manual": Requires explicit processing using POST /v1/orders/{order_id}/process.
+        /// - "automatic": Processes the order immediately.
+        /// </remarks>
         public string ProcessingMode { get; set; }
 
         /// <summary>

--- a/src/MercadoPago/Client/Order/OrderPaymentMethodRequest.cs
+++ b/src/MercadoPago/Client/Order/OrderPaymentMethodRequest.cs
@@ -32,8 +32,10 @@ namespace MercadoPago.Client.Order
 
         /// <summary>
         /// Number of installments selected by the payer for this payment.
+        /// Only applicable to payment methods that support installments (e.g., credit cards).
+        /// Leave null for payment methods that do not support installments (e.g., Pix, bank transfer).
         /// </summary>
-        public int Installments { get; set; }
+        public int? Installments { get; set; }
 
         /// <summary>
         /// Financial institution code (required for PSE in Colombia, e.g. "1007" Bancolombia).


### PR DESCRIPTION
## Summary

- Change `OrderPaymentMethodRequest.Installments` from `int` to `int?` so it is omitted from serialization when not explicitly set
- Fix `OrderCreateRequest.ProcessingMode` XML docs to reflect actual supported values (`"manual"` / `"automatic"`) instead of the outdated `"aggregator"` / `"gateway"`

## Motivation

When creating an Order with a payment method that does not support installments (e.g., Pix, bank transfer), the SDK was always serializing `installments: 0` because `int` defaults to `0`. This caused the Mercado Pago API to reject the request with:

```
Status code: 400
API message error: Properties not supported
API message details: '$.transactions.payments[0].payment_method' - additionalProperties 'installments' not allowed
```

Making the property `int?` (nullable) means it is only serialized when explicitly assigned by the developer.

## Test plan

- [ ] Build passes: `dotnet build src/MercadoPago/MercadoPago.csproj --configuration Release`
- [ ] Existing unit tests pass: `dotnet test src/MercadoPago.Tests/MercadoPago.Tests.csproj`
- [ ] Verify Pix/bank transfer order creation no longer sends `installments` in the payload
- [ ] Verify credit card order creation still works when `Installments` is explicitly set

🤖 Generated with [Claude Code](https://claude.com/claude-code)