### PR TITLE
Pin GitHub Actions to SHA for supply chain security

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v6
         with:
           dotnet-version: '8.0.x'
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v6
         with:
           dotnet-version: '8.0.x'
 
@@ -38,6 +38,6 @@ jobs:
           USER_EMAIL: ${{ secrets.USER_EMAIL }}
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
         with:
           fail-on-severity: high


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to full SHA commit hashes to prevent supply chain attacks via mutable tags

## Changes
- `CD.yml`: `actions/checkout@v7` → `@df4cb1c...`, `actions/setup-dotnet@v6` → `@26b0ec14...`
- `CI.yml`: `actions/checkout@v7` → `@df4cb1c...`, `actions/setup-dotnet@v6` → `@26b0ec14...`, `actions/dependency-review-action@v5` → `@a1d282b3...`

## Test plan
- [ ] CI passes on this PR