### PR TITLE
Fix dependency-review step failing on push to master

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,7 @@ jobs:
           USER_EMAIL: ${{ secrets.USER_EMAIL }}
 
       - name: Dependency Review
+        if: github.event_name == 'pull_request'
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
         with:
           fail-on-severity: high


### PR DESCRIPTION
## Summary

- The \`Dependency Review\` CI step was running on both \`push\` to \`master\` and \`pull_request\` events
- \`actions/dependency-review-action\` requires a base ref and head ref, which are only available in \`pull_request\`/\`pull_request_target\`/\`merge_group\` events
- Added \`if: github.event_name == 'pull_request'\` condition so the step is skipped on direct pushes and only runs on PRs

## Test plan

- [ ] Verify CI passes on this PR (dependency-review step runs)
- [ ] Verify a direct push to master no longer triggers the failing dependency-review step

🤖 Generated with [Claude Code](https://claude.com/claude-code)