### PR TITLE
Add CREDENTIAL_ON_FILE messaging fields to Payment types

### DIFF
--- a/src/MercadoPago/Client/Payment/PaymentPointOfInteractionRequest.cs
+++ b/src/MercadoPago/Client/Payment/PaymentPointOfInteractionRequest.cs
@@ -15,9 +15,15 @@ namespace MercadoPago.Client.Payment
         public string LinkedTo { get; set; }
 
         /// <summary>
-        /// Type of the point of interaction (e.g., "PSP_TRANSFER", "CHECKOUT").
+        /// Type of the point of interaction (e.g., "PSP_TRANSFER", "CHECKOUT", "CREDENTIAL_ON_FILE").
         /// </summary>
         public string Type { get; set; }
+
+        /// <summary>
+        /// Sub-type providing further detail about the interaction channel
+        /// (e.g., a specific POS terminal type or checkout variant).
+        /// </summary>
+        public string SubType { get; set; }
 
         /// <summary>
         /// Transaction data associated with this point of interaction, including

--- a/src/MercadoPago/Client/Payment/PaymentReferenceRequest.cs
+++ b/src/MercadoPago/Client/Payment/PaymentReferenceRequest.cs
@@ -1,0 +1,15 @@
+namespace MercadoPago.Client.Payment
+{
+    /// <summary>
+    /// Reference to a related resource within a CREDENTIAL_ON_FILE payment flow,
+    /// used within <see cref="PaymentTransactionDataRequest"/> to link a mandate
+    /// or agreement identifier.
+    /// </summary>
+    public class PaymentReferenceRequest
+    {
+        /// <summary>
+        /// Identifier of the referenced resource (e.g., a mandate or agreement ID).
+        /// </summary>
+        public string Id { get; set; }
+    }
+}

--- a/src/MercadoPago/Client/Payment/PaymentTransactionDataRequest.cs
+++ b/src/MercadoPago/Client/Payment/PaymentTransactionDataRequest.cs
@@ -50,5 +50,32 @@ namespace MercadoPago.Client.Payment
         /// otherwise, <c>false</c>. Affects fraud analysis rules.
         /// </summary>
         public bool? UserPresent { get; set; }
+
+        /// <summary>
+        /// <c>true</c> if this is the first transaction stored under a
+        /// CREDENTIAL_ON_FILE agreement; otherwise, <c>false</c>.
+        /// </summary>
+        public bool FirstTransaction { get; set; }
+
+        /// <summary>
+        /// Storage stage of the credential-on-file agreement.
+        /// Use <c>"store"</c> when storing the credential for the first time,
+        /// or <c>"stored"</c> for subsequent uses of a stored credential.
+        /// </summary>
+        public string Storage { get; set; }
+
+        /// <summary>
+        /// Indicates who initiated the transaction.
+        /// Use <c>"customer"</c> for customer-initiated transactions (CIT)
+        /// or <c>"merchant"</c> for merchant-initiated transactions (MIT).
+        /// </summary>
+        public string TransactionInitiator { get; set; }
+
+        /// <summary>
+        /// Reference to a related resource within the CREDENTIAL_ON_FILE flow,
+        /// such as a mandate or agreement identifier.
+        /// </summary>
+        /// <seealso cref="PaymentReferenceRequest"/>
+        public PaymentReferenceRequest Reference { get; set; }
     }
 }

--- a/src/MercadoPago/Resource/Payment/PaymentReference.cs
+++ b/src/MercadoPago/Resource/Payment/PaymentReference.cs
@@ -1,0 +1,14 @@
+namespace MercadoPago.Resource.Payment
+{
+    /// <summary>
+    /// Reference to a related resource within <see cref="PaymentTransactionData"/>,
+    /// used to link a CREDENTIAL_ON_FILE payment to a mandate or agreement.
+    /// </summary>
+    public class PaymentReference
+    {
+        /// <summary>
+        /// Identifier of the referenced resource (e.g., a mandate or agreement ID).
+        /// </summary>
+        public string Id { get; set; }
+    }
+}

--- a/src/MercadoPago/Resource/Payment/PaymentTransactionData.cs
+++ b/src/MercadoPago/Resource/Payment/PaymentTransactionData.cs
@@ -95,5 +95,33 @@
         /// </summary>
         public bool? UserPresent { get; set; }
 
+        /// <summary>
+        /// Indicates whether this is the first transaction stored under a
+        /// CREDENTIAL_ON_FILE agreement (<c>true</c>) or a subsequent use
+        /// of a stored credential (<c>false</c>).
+        /// </summary>
+        public bool FirstTransaction { get; set; }
+
+        /// <summary>
+        /// Storage stage of the credential-on-file agreement.
+        /// Returns <c>"store"</c> when the credential is being stored for the first time,
+        /// or <c>"stored"</c> for subsequent uses.
+        /// </summary>
+        public string Storage { get; set; }
+
+        /// <summary>
+        /// Indicates who initiated the transaction.
+        /// Returns <c>"customer"</c> for customer-initiated transactions (CIT)
+        /// or <c>"merchant"</c> for merchant-initiated transactions (MIT).
+        /// </summary>
+        public string TransactionInitiator { get; set; }
+
+        /// <summary>
+        /// Reference to a related resource within the CREDENTIAL_ON_FILE flow,
+        /// such as a mandate or agreement identifier.
+        /// </summary>
+        /// <seealso cref="PaymentReference"/>
+        public PaymentReference Reference { get; set; }
+
     }
 }


### PR DESCRIPTION
## Summary

- Add `SubType` to `PaymentPointOfInteractionRequest` to support the `CREDENTIAL_ON_FILE` point-of-interaction type alongside existing types.
- Add `FirstTransaction` (bool), `Storage` (string), `TransactionInitiator` (string), and `Reference` (`PaymentReferenceRequest`) to `PaymentTransactionDataRequest` to carry credential-on-file metadata when building payment requests.
- Mirror the same four new fields in `PaymentTransactionData` (resource/response model) so API responses are fully deserialized.
- Create new `PaymentReferenceRequest` and `PaymentReference` classes (JSON key `"reference"`) to hold the mandate/agreement `Id`.
- All legacy fields (`FirstTimeUse`, `UserPresent`, `PaymentReference`) are preserved for backwards compatibility.

## Test plan

- [ ] Build passes: `dotnet build src/MercadoPago/MercadoPago.csproj --configuration Release` — 0 errors confirmed locally.
- [ ] Construct a `PaymentCreateRequest` with `PointOfInteraction.Type = "CREDENTIAL_ON_FILE"`, `PointOfInteraction.SubType`, and `TransactionData.FirstTransaction`, `Storage`, `TransactionInitiator`, and `Reference` populated; serialize and verify snake_case JSON output (`first_transaction`, `storage`, `transaction_initiator`, `reference`).
- [ ] Deserialize a mock API response containing the new fields and verify they map correctly to `PaymentTransactionData`.
- [ ] Confirm existing subscription-flow fields (`FirstTimeUse`, `UserPresent`, `PaymentReference`, `SubscriptionSequence`, etc.) still serialize/deserialize as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)