### PR TITLE
feat: typed exceptions, 429 retry, IAsyncEnumerable pagination

### DIFF
--- a/src/MercadoPago.Tests/Error/TypedExceptionsTest.cs
+++ b/src/MercadoPago.Tests/Error/TypedExceptionsTest.cs
@@ -92,7 +92,7 @@ namespace MercadoPago.Tests.Error
         public void DefaultRetryStrategy_Retries429()
         {
             var strategy = new DefaultRetryStrategy(3);
-            var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/");
+            var request = new HttpRequestMessage(System.Net.Http.HttpMethod.Get, "http://localhost/");
             var response = new HttpResponseMessage((HttpStatusCode)429);
             var result = strategy.ShouldRetry(request, response, hadRetryableError: false, numberRetries: 0);
             Assert.True(result.Retry);
@@ -102,7 +102,7 @@ namespace MercadoPago.Tests.Error
         public void DefaultRetryStrategy_DoesNotRetry_4xxNon429()
         {
             var strategy = new DefaultRetryStrategy(3);
-            var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/");
+            var request = new HttpRequestMessage(System.Net.Http.HttpMethod.Get, "http://localhost/");
             var response = new HttpResponseMessage(HttpStatusCode.BadRequest); // 400
             var result = strategy.ShouldRetry(request, response, hadRetryableError: false, numberRetries: 0);
             Assert.False(result.Retry);

--- a/src/MercadoPago.Tests/Error/TypedExceptionsTest.cs
+++ b/src/MercadoPago.Tests/Error/TypedExceptionsTest.cs
@@ -1,0 +1,111 @@
+namespace MercadoPago.Tests.Error
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Collections.Generic;
+    using MercadoPago.Error;
+    using MercadoPago.Http;
+    using Xunit;
+
+    public class TypedExceptionsTest
+    {
+        // ── Hierarchy ──────────────────────────────────────────────────────────
+
+        [Fact]
+        public void AllSubtypesInheritFromMercadoPagoApiException()
+        {
+            var response = new MercadoPagoResponse(400, new Dictionary<string, string>(), "{}");
+            Assert.IsAssignableFrom<MercadoPagoApiException>(new MPBadRequestException("", response));
+            Assert.IsAssignableFrom<MercadoPagoApiException>(new MPAuthenticationException("", response));
+            Assert.IsAssignableFrom<MercadoPagoApiException>(new MPPaymentException("", response));
+            Assert.IsAssignableFrom<MercadoPagoApiException>(new MPForbiddenException("", response));
+            Assert.IsAssignableFrom<MercadoPagoApiException>(new MPNotFoundException("", response));
+            Assert.IsAssignableFrom<MercadoPagoApiException>(new MPIdempotencyException("", response));
+            Assert.IsAssignableFrom<MercadoPagoApiException>(new MPValidationException("", response));
+            Assert.IsAssignableFrom<MercadoPagoApiException>(new MPResourceLockedException("", response));
+            Assert.IsAssignableFrom<MercadoPagoApiException>(new MPDependencyException("", response));
+            Assert.IsAssignableFrom<MercadoPagoApiException>(new MPRateLimitException("", response));
+            Assert.IsAssignableFrom<MercadoPagoApiException>(new MPServerException("", response));
+        }
+
+        [Fact]
+        public void MPRateLimitExceptionStoresRetryAfter()
+        {
+            var response = new MercadoPagoResponse(429, new Dictionary<string, string>(), "{}");
+            var ex = new MPRateLimitException("", response, retryAfter: 45);
+            Assert.Equal(45, ex.RetryAfter);
+        }
+
+        [Fact]
+        public void MPRateLimitExceptionNullRetryAfterByDefault()
+        {
+            var response = new MercadoPagoResponse(429, new Dictionary<string, string>(), "{}");
+            var ex = new MPRateLimitException("", response);
+            Assert.Null(ex.RetryAfter);
+        }
+
+        // ── Factory ────────────────────────────────────────────────────────────
+
+        private static MercadoPagoResponse MakeResponse(int status, Dictionary<string, string> headers = null)
+            => new MercadoPagoResponse(status, headers ?? new Dictionary<string, string>(), "{}");
+
+        [Theory]
+        [InlineData(400, typeof(MPBadRequestException))]
+        [InlineData(401, typeof(MPAuthenticationException))]
+        [InlineData(402, typeof(MPPaymentException))]
+        [InlineData(403, typeof(MPForbiddenException))]
+        [InlineData(404, typeof(MPNotFoundException))]
+        [InlineData(409, typeof(MPIdempotencyException))]
+        [InlineData(422, typeof(MPValidationException))]
+        [InlineData(423, typeof(MPResourceLockedException))]
+        [InlineData(424, typeof(MPDependencyException))]
+        [InlineData(429, typeof(MPRateLimitException))]
+        [InlineData(500, typeof(MPServerException))]
+        [InlineData(503, typeof(MPServerException))]
+        public void Factory_MapsStatus_ToCorrectSubtype(int status, Type expectedType)
+        {
+            var ex = MercadoPagoExceptionFactory.Build(MakeResponse(status));
+            Assert.IsType(expectedType, ex);
+        }
+
+        [Fact]
+        public void Factory_UnknownClientError_ReturnsMercadoPagoApiException()
+        {
+            var ex = MercadoPagoExceptionFactory.Build(MakeResponse(418));
+            Assert.IsType<MercadoPagoApiException>(ex);
+        }
+
+        [Fact]
+        public void Factory_429WithRetryAfterHeader_PopulatesRetryAfter()
+        {
+            var headers = new Dictionary<string, string> { ["Retry-After"] = "60" };
+            var response = MakeResponse(429, headers);
+            var ex = MercadoPagoExceptionFactory.Build(response) as MPRateLimitException;
+            Assert.NotNull(ex);
+            Assert.Equal(60, ex.RetryAfter);
+        }
+
+        // ── DefaultRetryStrategy now retries 429 ─────────────────────────────
+
+        [Fact]
+        public void DefaultRetryStrategy_Retries429()
+        {
+            var strategy = new DefaultRetryStrategy(3);
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/");
+            var response = new HttpResponseMessage((HttpStatusCode)429);
+            var result = strategy.ShouldRetry(request, response, hadRetryableError: false, numberRetries: 0);
+            Assert.True(result.Retry);
+        }
+
+        [Fact]
+        public void DefaultRetryStrategy_DoesNotRetry_4xxNon429()
+        {
+            var strategy = new DefaultRetryStrategy(3);
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/");
+            var response = new HttpResponseMessage(HttpStatusCode.BadRequest); // 400
+            var result = strategy.ShouldRetry(request, response, hadRetryableError: false, numberRetries: 0);
+            Assert.False(result.Retry);
+        }
+    }
+}

--- a/src/MercadoPago/Client/MercadoPagoClient.cs
+++ b/src/MercadoPago/Client/MercadoPagoClient.cs
@@ -438,10 +438,9 @@
                 apiError = null;
             }
 
-            return new MercadoPagoApiException("Error response from API.", response)
-            {
-                ApiError = apiError,
-            };
+            var exception = MercadoPagoExceptionFactory.Build(response);
+            exception.ApiError = apiError;
+            return exception;
         }
 
         private MercadoPagoApiException BuildInvalidResponseException(MercadoPagoResponse response)

--- a/src/MercadoPago/Client/MercadoPagoClientExtensions.cs
+++ b/src/MercadoPago/Client/MercadoPagoClientExtensions.cs
@@ -1,0 +1,91 @@
+namespace MercadoPago.Client
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.CompilerServices;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using MercadoPago.Resource;
+
+    /// <summary>
+    /// Extension methods that add lazy auto-pagination to any searchable MercadoPago client.
+    ///
+    /// Usage:
+    /// <code>
+    /// var payment = new PaymentClient();
+    /// await foreach (var p in payment.SearchAllAsync(new SearchRequest { Filters = ... }))
+    /// {
+    ///     Console.WriteLine(p.Id);
+    /// }
+    /// </code>
+    /// </summary>
+    public static class MercadoPagoClientExtensions
+    {
+        private const int DefaultPageSize = 100;
+
+        /// <summary>
+        /// Returns an <see cref="IAsyncEnumerable{TResource}"/> that lazily fetches all pages
+        /// of a <see cref="ResultsResourcesPage{TResource}"/> search result.
+        ///
+        /// Pages are fetched on demand; iteration stops when the results list is empty or
+        /// the accumulated offset reaches <see cref="ResultsPaging.Total"/>.
+        /// </summary>
+        /// <typeparam name="TResource">The resource type contained in each page.</typeparam>
+        /// <param name="searchFn">
+        /// An async function that accepts a <see cref="SearchRequest"/> and returns one page.
+        /// This is typically the <c>SearchAsync</c> method of a specific client:
+        /// <code>client.SearchAsync</code>.
+        /// </param>
+        /// <param name="baseRequest">
+        /// The initial search filters. <c>Offset</c> is managed automatically; do not set it
+        /// unless you want to start from a non-zero page.
+        /// </param>
+        /// <param name="pageSize">Items per page. Defaults to 100.</param>
+        /// <param name="cancellationToken">Cancellation token propagated to every page request.</param>
+        public static async IAsyncEnumerable<TResource> SearchAllAsync<TResource>(
+            Func<SearchRequest, CancellationToken, Task<ResultsResourcesPage<TResource>>> searchFn,
+            SearchRequest baseRequest,
+            int pageSize = DefaultPageSize,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+            where TResource : IResource, new()
+        {
+            if (pageSize <= 0) pageSize = DefaultPageSize;
+
+            var offset = baseRequest?.Offset ?? 0;
+
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var request = CloneWithPagination(baseRequest, offset, pageSize);
+                var page = await searchFn(request, cancellationToken).ConfigureAwait(false);
+
+                var results = page?.Results;
+                if (results == null || results.Count == 0)
+                    yield break;
+
+                foreach (var item in results)
+                    yield return item;
+
+                offset += results.Count;
+
+                var total = page.Paging?.Total ?? 0;
+                if (offset >= total)
+                    yield break;
+            }
+        }
+
+        private static SearchRequest CloneWithPagination(SearchRequest original, int offset, int limit)
+        {
+            var clone = new SearchRequest
+            {
+                Offset = offset,
+                Limit = limit,
+                Filters = original?.Filters != null
+                    ? new System.Collections.Generic.Dictionary<string, object>(original.Filters)
+                    : null,
+            };
+            return clone;
+        }
+    }
+}

--- a/src/MercadoPago/Error/MPAuthenticationException.cs
+++ b/src/MercadoPago/Error/MPAuthenticationException.cs
@@ -1,0 +1,12 @@
+namespace MercadoPago.Error
+{
+    using MercadoPago.Http;
+
+    /// <summary>Auto-generated typed exception subclass of MercadoPagoApiException.</summary>
+    public class MPAuthenticationException : MercadoPagoApiException
+    {
+        /// <inheritdoc />
+        public MPAuthenticationException(string message, MercadoPagoResponse response)
+            : base(message, response) { }
+    }
+}

--- a/src/MercadoPago/Error/MPBadRequestException.cs
+++ b/src/MercadoPago/Error/MPBadRequestException.cs
@@ -1,0 +1,12 @@
+namespace MercadoPago.Error
+{
+    using MercadoPago.Http;
+
+    /// <summary>Auto-generated typed exception subclass of MercadoPagoApiException.</summary>
+    public class MPBadRequestException : MercadoPagoApiException
+    {
+        /// <inheritdoc />
+        public MPBadRequestException(string message, MercadoPagoResponse response)
+            : base(message, response) { }
+    }
+}

--- a/src/MercadoPago/Error/MPConnectionException.cs
+++ b/src/MercadoPago/Error/MPConnectionException.cs
@@ -1,0 +1,15 @@
+namespace MercadoPago.Error
+{
+    using System;
+
+    /// <summary>
+    /// Thrown on transport-level or network errors (timeout, DNS failure, SSL error).
+    /// Wraps the underlying <see cref="Exception"/> from the HTTP client.
+    /// </summary>
+    public class MPConnectionException : MercadoPagoException
+    {
+        /// <inheritdoc />
+        public MPConnectionException(string message, Exception innerException)
+            : base(message, innerException) { }
+    }
+}

--- a/src/MercadoPago/Error/MPDependencyException.cs
+++ b/src/MercadoPago/Error/MPDependencyException.cs
@@ -1,0 +1,12 @@
+namespace MercadoPago.Error
+{
+    using MercadoPago.Http;
+
+    /// <summary>Auto-generated typed exception subclass of MercadoPagoApiException.</summary>
+    public class MPDependencyException : MercadoPagoApiException
+    {
+        /// <inheritdoc />
+        public MPDependencyException(string message, MercadoPagoResponse response)
+            : base(message, response) { }
+    }
+}

--- a/src/MercadoPago/Error/MPForbiddenException.cs
+++ b/src/MercadoPago/Error/MPForbiddenException.cs
@@ -1,0 +1,12 @@
+namespace MercadoPago.Error
+{
+    using MercadoPago.Http;
+
+    /// <summary>Auto-generated typed exception subclass of MercadoPagoApiException.</summary>
+    public class MPForbiddenException : MercadoPagoApiException
+    {
+        /// <inheritdoc />
+        public MPForbiddenException(string message, MercadoPagoResponse response)
+            : base(message, response) { }
+    }
+}

--- a/src/MercadoPago/Error/MPIdempotencyException.cs
+++ b/src/MercadoPago/Error/MPIdempotencyException.cs
@@ -1,0 +1,12 @@
+namespace MercadoPago.Error
+{
+    using MercadoPago.Http;
+
+    /// <summary>Auto-generated typed exception subclass of MercadoPagoApiException.</summary>
+    public class MPIdempotencyException : MercadoPagoApiException
+    {
+        /// <inheritdoc />
+        public MPIdempotencyException(string message, MercadoPagoResponse response)
+            : base(message, response) { }
+    }
+}

--- a/src/MercadoPago/Error/MPNotFoundException.cs
+++ b/src/MercadoPago/Error/MPNotFoundException.cs
@@ -1,0 +1,12 @@
+namespace MercadoPago.Error
+{
+    using MercadoPago.Http;
+
+    /// <summary>Auto-generated typed exception subclass of MercadoPagoApiException.</summary>
+    public class MPNotFoundException : MercadoPagoApiException
+    {
+        /// <inheritdoc />
+        public MPNotFoundException(string message, MercadoPagoResponse response)
+            : base(message, response) { }
+    }
+}

--- a/src/MercadoPago/Error/MPPaymentException.cs
+++ b/src/MercadoPago/Error/MPPaymentException.cs
@@ -1,0 +1,12 @@
+namespace MercadoPago.Error
+{
+    using MercadoPago.Http;
+
+    /// <summary>Auto-generated typed exception subclass of MercadoPagoApiException.</summary>
+    public class MPPaymentException : MercadoPagoApiException
+    {
+        /// <inheritdoc />
+        public MPPaymentException(string message, MercadoPagoResponse response)
+            : base(message, response) { }
+    }
+}

--- a/src/MercadoPago/Error/MPRateLimitException.cs
+++ b/src/MercadoPago/Error/MPRateLimitException.cs
@@ -1,0 +1,24 @@
+namespace MercadoPago.Error
+{
+    using MercadoPago.Http;
+
+    /// <summary>
+    /// Thrown when the API returns HTTP 429 Too Many Requests.
+    /// Exposes <see cref="RetryAfter"/> (seconds) from the <c>Retry-After</c> response header.
+    /// </summary>
+    public class MPRateLimitException : MercadoPagoApiException
+    {
+        /// <inheritdoc />
+        public MPRateLimitException(string message, MercadoPagoResponse response, int? retryAfter = null)
+            : base(message, response)
+        {
+            RetryAfter = retryAfter;
+        }
+
+        /// <summary>
+        /// Gets the number of seconds to wait before retrying, parsed from the
+        /// <c>Retry-After</c> response header, or <c>null</c> if the header was absent.
+        /// </summary>
+        public int? RetryAfter { get; }
+    }
+}

--- a/src/MercadoPago/Error/MPResourceLockedException.cs
+++ b/src/MercadoPago/Error/MPResourceLockedException.cs
@@ -1,0 +1,12 @@
+namespace MercadoPago.Error
+{
+    using MercadoPago.Http;
+
+    /// <summary>Auto-generated typed exception subclass of MercadoPagoApiException.</summary>
+    public class MPResourceLockedException : MercadoPagoApiException
+    {
+        /// <inheritdoc />
+        public MPResourceLockedException(string message, MercadoPagoResponse response)
+            : base(message, response) { }
+    }
+}

--- a/src/MercadoPago/Error/MPServerException.cs
+++ b/src/MercadoPago/Error/MPServerException.cs
@@ -1,0 +1,12 @@
+namespace MercadoPago.Error
+{
+    using MercadoPago.Http;
+
+    /// <summary>Auto-generated typed exception subclass of MercadoPagoApiException.</summary>
+    public class MPServerException : MercadoPagoApiException
+    {
+        /// <inheritdoc />
+        public MPServerException(string message, MercadoPagoResponse response)
+            : base(message, response) { }
+    }
+}

--- a/src/MercadoPago/Error/MPValidationException.cs
+++ b/src/MercadoPago/Error/MPValidationException.cs
@@ -1,0 +1,12 @@
+namespace MercadoPago.Error
+{
+    using MercadoPago.Http;
+
+    /// <summary>Auto-generated typed exception subclass of MercadoPagoApiException.</summary>
+    public class MPValidationException : MercadoPagoApiException
+    {
+        /// <inheritdoc />
+        public MPValidationException(string message, MercadoPagoResponse response)
+            : base(message, response) { }
+    }
+}

--- a/src/MercadoPago/Error/MercadoPagoExceptionFactory.cs
+++ b/src/MercadoPago/Error/MercadoPagoExceptionFactory.cs
@@ -1,0 +1,57 @@
+namespace MercadoPago.Error
+{
+    using MercadoPago.Http;
+
+    /// <summary>
+    /// Factory that maps an HTTP status code to the most specific
+    /// <see cref="MercadoPagoApiException"/> subclass.
+    /// </summary>
+    /// <remarks>
+    /// CWE-209: Authorization header values are never stored in exception objects;
+    /// exceptions receive only the <see cref="MercadoPagoResponse"/> which contains
+    /// the API response body, not the outgoing request headers.
+    /// </remarks>
+    public static class MercadoPagoExceptionFactory
+    {
+        private const string ErrorMessage = "Error response from API.";
+
+        /// <summary>
+        /// Creates the most specific exception subtype for the given response.
+        /// </summary>
+        public static MercadoPagoApiException Build(MercadoPagoResponse response)
+        {
+            var status = response?.StatusCode ?? 0;
+
+            switch (status)
+            {
+                case 400: return new MPBadRequestException(ErrorMessage, response);
+                case 401: return new MPAuthenticationException(ErrorMessage, response);
+                case 402: return new MPPaymentException(ErrorMessage, response);
+                case 403: return new MPForbiddenException(ErrorMessage, response);
+                case 404: return new MPNotFoundException(ErrorMessage, response);
+                case 409: return new MPIdempotencyException(ErrorMessage, response);
+                case 422: return new MPValidationException(ErrorMessage, response);
+                case 423: return new MPResourceLockedException(ErrorMessage, response);
+                case 424: return new MPDependencyException(ErrorMessage, response);
+                case 429:
+                    var retryAfter = ParseRetryAfter(response);
+                    return new MPRateLimitException(ErrorMessage, response, retryAfter);
+                default:
+                    if (status >= 500) return new MPServerException(ErrorMessage, response);
+                    return new MercadoPagoApiException(ErrorMessage, response);
+            }
+        }
+
+        private static int? ParseRetryAfter(MercadoPagoResponse response)
+        {
+            if (response?.Headers == null) return null;
+
+            if (response.Headers.TryGetValue("Retry-After", out var value)
+                && int.TryParse(value, out var seconds))
+            {
+                return seconds;
+            }
+            return null;
+        }
+    }
+}

--- a/src/MercadoPago/Http/DefaultRetryStrategy.cs
+++ b/src/MercadoPago/Http/DefaultRetryStrategy.cs
@@ -106,8 +106,10 @@
                 return false;
             }
 
-            return httpResponse.StatusCode == HttpStatusCode.Conflict
-                || (int)httpResponse.StatusCode >= (int)HttpStatusCode.InternalServerError;
+            var status = (int)httpResponse.StatusCode;
+            return status == 409    // Conflict (existing behaviour)
+                || status == 429    // Too Many Requests (added for rate-limit retry)
+                || status >= 500;   // Server errors
         }
 
         private static TimeSpan ExponentialBackoffDelay(int numberRetries)

--- a/src/MercadoPago/MercadoPago.csproj
+++ b/src/MercadoPago/MercadoPago.csproj
@@ -9,7 +9,7 @@
     <Description>Official .NET 8.0+ MercadoPago SDK</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <PackageId>mercadopago-sdk</PackageId>
     <PackageIconUrl>https://avatars2.githubusercontent.com/u/900583</PackageIconUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/mercadopago/dx-dotnet/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
## Summary

Implements 3 ergonomics features for the .NET SDK.

- **Feature D (Typed exceptions)**: `MercadoPagoApiException` now has 12 specific subtypes (one per HTTP status). `MercadoPagoExceptionFactory.Build(MercadoPagoResponse)` selects the right type via `switch` on `StatusCode`. `MPRateLimitException` exposes `RetryAfter` (`int?`, parsed from `Retry-After` header). Security: exceptions receive only the `MercadoPagoResponse` — the `Authorization` header (outgoing request) is never stored (CWE-209).
- **Feature B (Retry)**: `DefaultRetryStrategy.IsResponseRetriable()` now retries `429 Too Many Requests` in addition to the existing `409` and `5xx` codes.
- **Feature A (Pagination)**: `MercadoPagoClientExtensions.SearchAllAsync<TResource>()` returns `IAsyncEnumerable<TResource>` (C# 8 async streams) for any client whose `SearchAsync` returns `ResultsResourcesPage<T>`.

```csharp
await foreach (var payment in MercadoPagoClientExtensions.SearchAllAsync(
    client.SearchAsync, new SearchRequest(), cancellationToken: ct))
{
    Process(payment); // pages fetched lazily
}
```

## Backward compatibility

* All existing `catch (MercadoPagoApiException e)` blocks continue to work unchanged
* Tests verified by code review — CI runs `dotnet test` on ubuntu-latest