### PR TITLE
chore: bump version to 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Releases
 
+## VERSION 3.4.0 - 2026-08-04
+- feat: SDK ergonomics — typed exceptions, configurable retry and auto-pagination ([#265](https://github.com/mercadopago/sdk-dotnet/pull/265)). `MercadoPagoApiException` now has 12 specific subtypes per HTTP status code. Request options gain optional `MaxRetries`, `RetryOn`, `InitialDelayMs`, `MaxDelayMs` and `OnRetry` callback. New auto-pagination support on search endpoints.
+- feat: add missing API methods — `DisbursementRefundClient.List()`, `AdvancedPaymentClient.Update()`, `CustomerCardClient.Update()`, `PaymentClient.Update()` ([#264](https://github.com/mercadopago/sdk-dotnet/pull/264))
+- feat: add CREDENTIAL_ON_FILE messaging fields to Payment types ([#261](https://github.com/mercadopago/sdk-dotnet/pull/261)): `FirstTransaction`, `Storage`, `TransactionInitiator`, `Reference`
+- fix: webhook `ToleranceSeconds` unit mismatch — `ts` header value compared in seconds against a millisecond clock ([#266](https://github.com/mercadopago/sdk-dotnet/pull/266))
+- fix: `ConstantTimeEquals` error on multibyte v1 hash ([#266](https://github.com/mercadopago/sdk-dotnet/pull/266))
+- fix(order): make `OrderPaymentMethod.Installments` nullable to prevent serialization errors for non-card payments (Pix, bank_transfer) ([#259](https://github.com/mercadopago/sdk-dotnet/pull/259))
+- Bump `actions/checkout` to `v7.0.1` ([#263](https://github.com/mercadopago/sdk-dotnet/pull/263))
+- Bump `actions/setup-dotnet` to `v6.0.0` ([#260](https://github.com/mercadopago/sdk-dotnet/pull/260))
+
 ## VERSION 3.3.0 - 2026-06-30
 - PreApprovalPlan: subscription plan template management — Create, Get, Update, Search (`POST/GET/PUT /preapproval_plan`).
 - Point: in-person payment intent management for Point devices — Create, Get, Cancel (`POST/GET/DELETE /point/integration-api/...`).

--- a/src/MercadoPago/MercadoPago.csproj
+++ b/src/MercadoPago/MercadoPago.csproj
@@ -18,8 +18,8 @@
     <SignAssembly>True</SignAssembly>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
-    <Version>3.3.1</Version>
-    <VersionPrefix>3.3.1</VersionPrefix>
+    <Version>3.4.0</Version>
+    <VersionPrefix>3.4.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Bump version from `3.3.1` to `3.4.0`
- Update `src/MercadoPago/MercadoPago.csproj` and `CHANGELOG.md`

## Changelog entry

- feat: SDK ergonomics — typed exceptions, configurable retry and auto-pagination ([#265](https://github.com/mercadopago/sdk-dotnet/pull/265))
- feat: add missing API methods — `DisbursementRefundClient.List()`, `AdvancedPaymentClient.Update()`, `CustomerCardClient.Update()`, `PaymentClient.Update()` ([#264](https://github.com/mercadopago/sdk-dotnet/pull/264))
- feat: add CREDENTIAL_ON_FILE messaging fields to Payment types ([#261](https://github.com/mercadopago/sdk-dotnet/pull/261)): `FirstTransaction`, `Storage`, `TransactionInitiator`, `Reference`
- fix: webhook `ToleranceSeconds` unit mismatch ([#266](https://github.com/mercadopago/sdk-dotnet/pull/266))
- fix: `ConstantTimeEquals` error on multibyte v1 hash ([#266](https://github.com/mercadopago/sdk-dotnet/pull/266))
- fix(order): make `OrderPaymentMethod.Installments` nullable to prevent serialization errors for non-card payments ([#259](https://github.com/mercadopago/sdk-dotnet/pull/259))
- Bump `actions/checkout` to `v7.0.1` ([#263](https://github.com/mercadopago/sdk-dotnet/pull/263))
- Bump `actions/setup-dotnet` to `v6.0.0` ([#260](https://github.com/mercadopago/sdk-dotnet/pull/260))

## Test plan
- [ ] CI passes
- [ ] Version string is correct in all files