### PR TITLE
feat: add COF network data support + bump version to 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Releases
 
+## VERSION 3.6.0 - 2026-08-25
+- feat: add COF network data support — new fields on `PaymentNetworkDataRequest`/`PaymentNetworkData`, `PaymentPointOfInteractionRequest`/`PaymentPointOfInteraction`, and `OrderStoredCredential`
+
 ## VERSION 3.5.0 - 2026-08-11
 - feat(order): add Automatic Payments example — two-step recurring flow ([#262](https://github.com/mercadopago/sdk-dotnet/pull/262))
 - feat: add `Update` to `PaymentClient` ([#262](https://github.com/mercadopago/sdk-dotnet/pull/262))

--- a/src/MercadoPago/Client/Payment/PaymentNetworkDataRequest.cs
+++ b/src/MercadoPago/Client/Payment/PaymentNetworkDataRequest.cs
@@ -1,0 +1,8 @@
+namespace MercadoPago.Client.Payment
+{
+    public class PaymentNetworkDataRequest
+    {
+        public string NetworkTransactionId { get; set; }
+        public string TransactionLinkId { get; set; }
+    }
+}

--- a/src/MercadoPago/Client/Payment/PaymentNetworkDataRequest.cs
+++ b/src/MercadoPago/Client/Payment/PaymentNetworkDataRequest.cs
@@ -1,8 +1,19 @@
 namespace MercadoPago.Client.Payment
 {
+    /// <summary>
+    /// Card-network identifiers sent in the point of interaction for a
+    /// credential-on-file payment.
+    /// </summary>
     public class PaymentNetworkDataRequest
     {
+        /// <summary>
+        /// Identifier assigned to the transaction by the card network.
+        /// </summary>
         public string NetworkTransactionId { get; set; }
+
+        /// <summary>
+        /// Identifier that links related transactions in the card network.
+        /// </summary>
         public string TransactionLinkId { get; set; }
     }
 }

--- a/src/MercadoPago/Client/Payment/PaymentPointOfInteractionRequest.cs
+++ b/src/MercadoPago/Client/Payment/PaymentPointOfInteractionRequest.cs
@@ -32,6 +32,10 @@ namespace MercadoPago.Client.Payment
         /// <seealso cref="PaymentTransactionDataRequest"/>
         public PaymentTransactionDataRequest TransactionData { get; set; }
 
+        /// <summary>
+        /// Card-network identifiers for a credential-on-file payment.
+        /// </summary>
+        /// <seealso cref="PaymentNetworkDataRequest"/>
         public PaymentNetworkDataRequest NetworkData { get; set; }
     }
 }

--- a/src/MercadoPago/Client/Payment/PaymentPointOfInteractionRequest.cs
+++ b/src/MercadoPago/Client/Payment/PaymentPointOfInteractionRequest.cs
@@ -31,5 +31,7 @@ namespace MercadoPago.Client.Payment
         /// </summary>
         /// <seealso cref="PaymentTransactionDataRequest"/>
         public PaymentTransactionDataRequest TransactionData { get; set; }
+
+        public PaymentNetworkDataRequest NetworkData { get; set; }
     }
 }

--- a/src/MercadoPago/Client/Payment/PaymentTransactionDataRequest.cs
+++ b/src/MercadoPago/Client/Payment/PaymentTransactionDataRequest.cs
@@ -46,6 +46,11 @@ namespace MercadoPago.Client.Payment
         public string BillingDate { get; set; }
 
         /// <summary>
+        /// Legacy card-network transaction identifier within transaction data.
+        /// </summary>
+        public string NetworkTransactionId { get; set; }
+
+        /// <summary>
         /// <c>true</c> if the user (cardholder) is present during the transaction;
         /// otherwise, <c>false</c>. Affects fraud analysis rules.
         /// </summary>

--- a/src/MercadoPago/MercadoPago.csproj
+++ b/src/MercadoPago/MercadoPago.csproj
@@ -18,8 +18,8 @@
     <SignAssembly>True</SignAssembly>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
-    <Version>3.5.0</Version>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <Version>3.6.0</Version>
+    <VersionPrefix>3.6.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MercadoPago/Resource/Order/OrderStoredCredential.cs
+++ b/src/MercadoPago/Resource/Order/OrderStoredCredential.cs
@@ -27,5 +27,8 @@ namespace MercadoPago.Resource.Order
         /// Indicates whether this is the first payment in a series using these stored credentials.
         /// </summary>
         public bool? FirstPayment { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("previous_transaction_reference")]
+        public string PreviousTransactionReference { get; set; }
     }
 }

--- a/src/MercadoPago/Resource/Payment/PaymentNetworkData.cs
+++ b/src/MercadoPago/Resource/Payment/PaymentNetworkData.cs
@@ -1,8 +1,19 @@
 namespace MercadoPago.Resource.Payment
 {
+    /// <summary>
+    /// Card-network identifiers returned in the point of interaction for a
+    /// credential-on-file payment.
+    /// </summary>
     public class PaymentNetworkData
     {
+        /// <summary>
+        /// Identifier assigned to the transaction by the card network.
+        /// </summary>
         public string NetworkTransactionId { get; set; }
+
+        /// <summary>
+        /// Identifier that links related transactions in the card network.
+        /// </summary>
         public string TransactionLinkId { get; set; }
     }
 }

--- a/src/MercadoPago/Resource/Payment/PaymentNetworkData.cs
+++ b/src/MercadoPago/Resource/Payment/PaymentNetworkData.cs
@@ -1,0 +1,8 @@
+namespace MercadoPago.Resource.Payment
+{
+    public class PaymentNetworkData
+    {
+        public string NetworkTransactionId { get; set; }
+        public string TransactionLinkId { get; set; }
+    }
+}

--- a/src/MercadoPago/Resource/Payment/PaymentPointOfInteraction.cs
+++ b/src/MercadoPago/Resource/Payment/PaymentPointOfInteraction.cs
@@ -39,6 +39,10 @@
         /// <seealso cref="PaymentTransactionData"/>
         public PaymentTransactionData TransactionData { get; set; }
 
+        /// <summary>
+        /// Card-network identifiers returned for a credential-on-file payment.
+        /// </summary>
+        /// <seealso cref="PaymentNetworkData"/>
         public PaymentNetworkData NetworkData { get; set; }
     }
 }

--- a/src/MercadoPago/Resource/Payment/PaymentPointOfInteraction.cs
+++ b/src/MercadoPago/Resource/Payment/PaymentPointOfInteraction.cs
@@ -38,5 +38,7 @@
         /// </summary>
         /// <seealso cref="PaymentTransactionData"/>
         public PaymentTransactionData TransactionData { get; set; }
+
+        public PaymentNetworkData NetworkData { get; set; }
     }
 }

--- a/src/MercadoPago/Resource/Payment/PaymentTransactionData.cs
+++ b/src/MercadoPago/Resource/Payment/PaymentTransactionData.cs
@@ -90,6 +90,11 @@
         public string BillingDate { get; set; }
 
         /// <summary>
+        /// Legacy card-network transaction identifier within transaction data.
+        /// </summary>
+        public string NetworkTransactionId { get; set; }
+
+        /// <summary>
         /// Indicates whether the payer was physically present during the
         /// transaction. Relevant for POS and in-person payment scenarios.
         /// </summary>


### PR DESCRIPTION
## Summary
- Add COF network data support: new fields on `PaymentNetworkDataRequest`/`PaymentNetworkData`, `PaymentPointOfInteractionRequest`/`PaymentPointOfInteraction`, and `OrderStoredCredential`
- Bump version from `3.5.0` to `3.6.0`
- Update `src/MercadoPago/MercadoPago.csproj` and `CHANGELOG.md`

## Test plan
- [ ] CI passes
- [ ] Version string is correct in all files